### PR TITLE
Keep track of the Upfile.lock MD5 to detect project changes

### DIFF
--- a/Assets/Plugins/Editor/Uplift/Common/FileSystemUtil.cs
+++ b/Assets/Plugins/Editor/Uplift/Common/FileSystemUtil.cs
@@ -229,9 +229,9 @@ namespace Uplift.Common
             return string.Join("/", path.Split('/', '\\'));
         }
 
-		public static string GetFileMD5(string path)
-		{
-			using(MD5 md5hash = MD5.Create())
+        public static string GetFileMD5(string path)
+        {
+            using(MD5 md5hash = MD5.Create())
             using(StreamReader file = new StreamReader(path))
             {
                 byte[] data = md5hash.ComputeHash(Encoding.UTF8.GetBytes(file.ReadToEnd()));
@@ -242,6 +242,6 @@ namespace Uplift.Common
                 }
                 return sBuilder.ToString();
             }
-		}
-	}
+        }
+    }
 }

--- a/Assets/Plugins/Editor/Uplift/Common/FileSystemUtil.cs
+++ b/Assets/Plugins/Editor/Uplift/Common/FileSystemUtil.cs
@@ -27,6 +27,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
+using System.Security.Cryptography;
 using UnityEditor;
 using UnityEngine;
 
@@ -226,5 +228,20 @@ namespace Uplift.Common
             if (string.IsNullOrEmpty(path)) { return path; }
             return string.Join("/", path.Split('/', '\\'));
         }
+
+		public static string GetFileMD5(string path)
+		{
+			using(MD5 md5hash = MD5.Create())
+            using(StreamReader file = new StreamReader(path))
+            {
+                byte[] data = md5hash.ComputeHash(Encoding.UTF8.GetBytes(file.ReadToEnd()));
+                StringBuilder sBuilder = new StringBuilder();
+                for (int i = 0; i < data.Length; i++)
+                {
+                    sBuilder.Append(data[i].ToString("x2"));
+                }
+                return sBuilder.ToString();
+            }
+		}
 	}
 }

--- a/Assets/Plugins/Editor/Uplift/Initialize.cs
+++ b/Assets/Plugins/Editor/Uplift/Initialize.cs
@@ -27,6 +27,9 @@ using UnityEngine;
 using Uplift.Common;
 using Uplift.Schemas;
 using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace Uplift
 {
@@ -52,12 +55,27 @@ namespace Uplift
 
         private static bool IsInitialized()
         {
-            return string.Equals(Environment.GetEnvironmentVariable(env_variable), "true");
+            return string.Equals(Environment.GetEnvironmentVariable(env_variable), GetLockfileMD5());
         }
 
         private static void MarkAsInitialized()
         {
-            Environment.SetEnvironmentVariable(env_variable, "true");
+            Environment.SetEnvironmentVariable(env_variable, GetLockfileMD5());
+        }
+
+        private static string GetLockfileMD5()
+        {
+            using(MD5 md5hash = MD5.Create())
+            using(StreamReader file = new StreamReader(UpliftManager.lockfilePath))
+            {
+                byte[] data = md5hash.ComputeHash(Encoding.UTF8.GetBytes(file.ReadToEnd()));
+                StringBuilder sBuilder = new StringBuilder();
+                for (int i = 0; i < data.Length; i++)
+                {
+                    sBuilder.Append(data[i].ToString("x2"));
+                }
+                return sBuilder.ToString();
+            }
         }
     }
 }

--- a/Assets/Plugins/Editor/Uplift/Initialize.cs
+++ b/Assets/Plugins/Editor/Uplift/Initialize.cs
@@ -42,21 +42,11 @@ namespace Uplift
                 SampleFile.CreateSampleUpfile();
             }
             
-            if(!IsInitialized())
+            if(LockFileTracker.HasChanged())
             {
-                UpliftManager manager = UpliftManager.Instance();
-                manager.InstallDependencies(strategy: UpliftManager.InstallStrategy.ONLY_LOCKFILE, refresh: true);
-                manager.StoreLockfileMD5Environnment();
+                UpliftManager.Instance().InstallDependencies(strategy: UpliftManager.InstallStrategy.ONLY_LOCKFILE, refresh: true);
+                LockFileTracker.SaveState();
             }
-        }
-
-        private static bool IsInitialized()
-        {
-            UpliftManager manager = UpliftManager.Instance();
-            return string.Equals(
-                Environment.GetEnvironmentVariable(UpliftManager.env_variable),
-                manager.GetLockfileMD5()
-            );
         }
     }
 }

--- a/Assets/Plugins/Editor/Uplift/Initialize.cs
+++ b/Assets/Plugins/Editor/Uplift/Initialize.cs
@@ -27,16 +27,12 @@ using UnityEngine;
 using Uplift.Common;
 using Uplift.Schemas;
 using System;
-using System.IO;
-using System.Security.Cryptography;
-using System.Text;
 
 namespace Uplift
 {
     [InitializeOnLoad]
     public class Initialize : MonoBehaviour
     {
-        private static readonly string env_variable = "UPLIFT_INSTALLATION_DONE";
         static Initialize()
         {
             Debug.Log("Upfile loading...");
@@ -48,34 +44,19 @@ namespace Uplift
             
             if(!IsInitialized())
             {
-                UpliftManager.Instance().InstallDependencies(strategy: UpliftManager.InstallStrategy.ONLY_LOCKFILE, refresh: true);
-                MarkAsInitialized();
+                UpliftManager manager = UpliftManager.Instance();
+                manager.InstallDependencies(strategy: UpliftManager.InstallStrategy.ONLY_LOCKFILE, refresh: true);
+                manager.StoreLockfileMD5Environnment();
             }
         }
 
         private static bool IsInitialized()
         {
-            return string.Equals(Environment.GetEnvironmentVariable(env_variable), GetLockfileMD5());
-        }
-
-        private static void MarkAsInitialized()
-        {
-            Environment.SetEnvironmentVariable(env_variable, GetLockfileMD5());
-        }
-
-        private static string GetLockfileMD5()
-        {
-            using(MD5 md5hash = MD5.Create())
-            using(StreamReader file = new StreamReader(UpliftManager.lockfilePath))
-            {
-                byte[] data = md5hash.ComputeHash(Encoding.UTF8.GetBytes(file.ReadToEnd()));
-                StringBuilder sBuilder = new StringBuilder();
-                for (int i = 0; i < data.Length; i++)
-                {
-                    sBuilder.Append(data[i].ToString("x2"));
-                }
-                return sBuilder.ToString();
-            }
+            UpliftManager manager = UpliftManager.Instance();
+            return string.Equals(
+                Environment.GetEnvironmentVariable(UpliftManager.env_variable),
+                manager.GetLockfileMD5()
+            );
         }
     }
 }

--- a/Assets/Plugins/Editor/Uplift/LockfFileTracker.cs
+++ b/Assets/Plugins/Editor/Uplift/LockfFileTracker.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Uplift
+{
+    public class LockFileTracker
+    {
+        private static readonly string envVariable = "UPFILE_LOCK_MD5";
+
+        public static bool HasChanged()
+        {
+            string currentMD5 = Uplift.Common.FileSystemUtil.GetFileMD5(UpliftManager.lockfilePath);
+            string oldMD5 = Environment.GetEnvironmentVariable(envVariable);
+
+            return !string.Equals(currentMD5, oldMD5);
+        }
+
+        public static void SaveState()
+        {
+            Environment.SetEnvironmentVariable(envVariable, Uplift.Common.FileSystemUtil.GetFileMD5(UpliftManager.lockfilePath));
+        }
+    }
+}

--- a/Assets/Plugins/Editor/Uplift/LockfFileTracker.cs.meta
+++ b/Assets/Plugins/Editor/Uplift/LockfFileTracker.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 1c1f5182d7a9ae64fb27c615b2210634
+timeCreated: 1510309497
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Editor/Uplift/UpliftManager.cs
+++ b/Assets/Plugins/Editor/Uplift/UpliftManager.cs
@@ -33,8 +33,6 @@ using System.Text.RegularExpressions;
 using UnityEditor;
 using System;
 using System.Collections.Generic;
-using System.Security.Cryptography;
-using System.Text;
 
 namespace Uplift
 {
@@ -73,8 +71,6 @@ namespace Uplift
 
         // --- CLASS DECLARATION ---
         public static readonly string lockfilePath = "Upfile.lock";
-        public static readonly string env_variable = "UPFILE_LOCK_MD5";
-
         protected Upfile upfile;
 
         public enum InstallStrategy {
@@ -315,7 +311,7 @@ namespace Uplift
                 file.WriteLine(result);
             }
 
-            StoreLockfileMD5Environnment();
+            LockFileTracker.SaveState();
         }
 
         private LockfileSnapshot LoadLockfile()
@@ -396,26 +392,6 @@ namespace Uplift
             }
             
             return result;
-        }
-
-        public void StoreLockfileMD5Environnment()
-        {
-            Environment.SetEnvironmentVariable(env_variable, GetLockfileMD5());
-        }
-
-        public string GetLockfileMD5()
-        {
-            using(MD5 md5hash = MD5.Create())
-            using(StreamReader file = new StreamReader(UpliftManager.lockfilePath))
-            {
-                byte[] data = md5hash.ComputeHash(Encoding.UTF8.GetBytes(file.ReadToEnd()));
-                StringBuilder sBuilder = new StringBuilder();
-                for (int i = 0; i < data.Length; i++)
-                {
-                    sBuilder.Append(data[i].ToString("x2"));
-                }
-                return sBuilder.ToString();
-            }
         }
 
         public void InstallPackages(PackageRepo[] targets)

--- a/Assets/Plugins/Editor/Uplift/UpliftManager.cs
+++ b/Assets/Plugins/Editor/Uplift/UpliftManager.cs
@@ -33,6 +33,8 @@ using System.Text.RegularExpressions;
 using UnityEditor;
 using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace Uplift
 {
@@ -71,6 +73,8 @@ namespace Uplift
 
         // --- CLASS DECLARATION ---
         public static readonly string lockfilePath = "Upfile.lock";
+        public static readonly string env_variable = "UPFILE_LOCK_MD5";
+
         protected Upfile upfile;
 
         public enum InstallStrategy {
@@ -310,6 +314,8 @@ namespace Uplift
             {
                 file.WriteLine(result);
             }
+
+            StoreLockfileMD5Environnment();
         }
 
         private LockfileSnapshot LoadLockfile()
@@ -390,6 +396,26 @@ namespace Uplift
             }
             
             return result;
+        }
+
+        public void StoreLockfileMD5Environnment()
+        {
+            Environment.SetEnvironmentVariable(env_variable, GetLockfileMD5());
+        }
+
+        public string GetLockfileMD5()
+        {
+            using(MD5 md5hash = MD5.Create())
+            using(StreamReader file = new StreamReader(UpliftManager.lockfilePath))
+            {
+                byte[] data = md5hash.ComputeHash(Encoding.UTF8.GetBytes(file.ReadToEnd()));
+                StringBuilder sBuilder = new StringBuilder();
+                for (int i = 0; i < data.Length; i++)
+                {
+                    sBuilder.Append(data[i].ToString("x2"));
+                }
+                return sBuilder.ToString();
+            }
         }
 
         public void InstallPackages(PackageRepo[] targets)


### PR DESCRIPTION
Instead of checking whether or not the project has been installed on editor launch with an environment variable containing `"true"`, the environment variable now stores the MD5 of the lockfile so it knows when the file has been changed, and when to trigger an installation.

This is useful for automated install on checkouts and pulls.