### PR TITLE
Fix Version requirement lose and bounded conflict

### DIFF
--- a/Assets/Plugins/Editor/Uplift/Common/VersionRequirements.cs
+++ b/Assets/Plugins/Editor/Uplift/Common/VersionRequirements.cs
@@ -282,6 +282,7 @@ namespace Uplift.Common
             else if(other is BoundedVersionRequirement)
             {
                 if (IsMetBy((other as BoundedVersionRequirement).lowerBound)) return other;
+                if ((other as BoundedVersionRequirement).IsMetBy(stub)) return this;
             }
             else if(other is ExactVersionRequirement)
             {
@@ -315,14 +316,10 @@ namespace Uplift.Common
 
         public IVersionRequirement RestrictTo(IVersionRequirement other)
         {
-            if (other is NoRequirement || other is MinimalVersionRequirement)
+            if (other is NoRequirement || other is MinimalVersionRequirement || other is LoseVersionRequirement)
             {
                 return other.RestrictTo(this);
-            }
-            else if(other is LoseVersionRequirement)
-            {
-                if (IsMetBy((other as LoseVersionRequirement).stub)) return other;
-            }
+            }   
             else if(other is BoundedVersionRequirement)
             {
                 if (IsMetBy((other as BoundedVersionRequirement).lowerBound)) return other;

--- a/Assets/Plugins/Editor/Uplift/Testing/UnitTesting/VersionRequirementTest.cs
+++ b/Assets/Plugins/Editor/Uplift/Testing/UnitTesting/VersionRequirementTest.cs
@@ -482,6 +482,9 @@ namespace Uplift.Testing.Unit
                 loseRequirement = new LoseVersionRequirement("1.0.1");
                 Assert.AreSame(requirement.RestrictTo(loseRequirement), loseRequirement);
 
+                // When losely comparable (1.0)
+                loseRequirement = new LoseVersionRequirement("1.0");
+                Assert.AreSame(requirement.RestrictTo(loseRequirement), requirement);
 
                 // When lesser (0.9)
                 loseRequirement = new LoseVersionRequirement("0.9");


### PR DESCRIPTION
LoseVersionRequirement (version) and BoundedVersionRequirement
(version*) are not supposed to be conflicting as they should be
compatible in the BoundedVersionRequirement which is the more
restrictive of the two.

This behaviour was correctly happening when LoseVersionRequirement was
restricted to BoundedVersionRequirement but not the other way around,
so this fixes it.

Fixes #12 