### PR TITLE
Compiler: use defines to make sure that .unitypackage is built correctly

### DIFF
--- a/Assets/Plugins/Editor/BuildTool/BuildLibraryData.cs
+++ b/Assets/Plugins/Editor/BuildTool/BuildLibraryData.cs
@@ -37,6 +37,7 @@ namespace BuildTool {
     public class BuildLibraryData {
         public string[] References;
         public string[] Files;
+        public string[] Defines;
         public int SdkLevel;
         public string OutFile;
         public bool useUnsafe = false;

--- a/Assets/Plugins/Editor/BuildTool/DllCompiler.cs
+++ b/Assets/Plugins/Editor/BuildTool/DllCompiler.cs
@@ -61,6 +61,10 @@ namespace BuildTool {
 			Data.SdkLevel = 2;
 			Data.OutFile = UpliftDLL;
 			Data.useUnsafe = true;
+			Data.Defines = new string[]
+			{
+				"UNITY_5_3_OR_NEWER"
+			};
 
 			unity.BuildLibrary(Data);
 		}

--- a/Assets/Plugins/Editor/BuildTool/DllCompiler.cs
+++ b/Assets/Plugins/Editor/BuildTool/DllCompiler.cs
@@ -61,10 +61,7 @@ namespace BuildTool {
 			Data.SdkLevel = 2;
 			Data.OutFile = UpliftDLL;
 			Data.useUnsafe = true;
-			Data.Defines = new string[]
-			{
-				"UNITY_5_3_OR_NEWER"
-			};
+			Data.Defines = EditorUserBuildSettings.activeScriptCompilationDefines;
 
 			unity.BuildLibrary(Data);
 		}

--- a/Assets/Plugins/Editor/BuildTool/UnityInstallation.cs
+++ b/Assets/Plugins/Editor/BuildTool/UnityInstallation.cs
@@ -64,6 +64,8 @@ namespace BuildTool {
 			args.Add ("-target:library");
 			args.Add ("-sdk:" + data.SdkLevel.ToString ());
 			args.Add ("-out:" + data.OutFile);
+			if(data.Defines != null && data.Defines.Length > 0)
+				args.Add("-define:" + string.Join(";", data.Defines));
 			if(data.useUnsafe)
 			    args.Add ("-unsafe");
 			args.AddRange (data.Files);

--- a/Assets/Plugins/Editor/Uplift/LogAggregator.cs
+++ b/Assets/Plugins/Editor/Uplift/LogAggregator.cs
@@ -30,7 +30,7 @@ using UnityEngine;
 
 namespace Uplift
 {
-#if (UNITY_5_3_OR_NEWER || UNITY_2017_1_OR_NEWER)
+#if UNITY_5_3_OR_NEWER
     class LogHandlerUtils {
         public static ILogHandler ReplaceLogHandler(ILogHandler newLogHandler) {
             ILogHandler currentLogHandler = Debug.logger.logHandler;

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,7 @@ GEM
 PLATFORMS
   ruby
   x64-mingw32
+  x86-mingw32
 
 DEPENDENCIES
   github_api (>= 0.18.0)


### PR DESCRIPTION
This provide an actual fix for the issue #20, and revert unnecessary changes from 659c909

Fixes #20