### PR TITLE
Fix lack of support for unknown repositories in Upfile Editor window

### DIFF
--- a/Assets/Plugins/Editor/Uplift/Windows/UpfileEditor.cs
+++ b/Assets/Plugins/Editor/Uplift/Windows/UpfileEditor.cs
@@ -140,6 +140,17 @@ namespace Uplift.Windows
             {
                 GithubRepository temp = (GithubRepository) repository;
                 temp.Url = EditorGUILayout.TextField("Url of github repository", temp.Url);
+
+                if(temp.TagList != null)
+                {
+                    temp.TagList = ArrayField<string>(
+                        temp.TagList,
+                        "Fetch from tag",
+                        "Add another tag",
+                        "sometag",
+                        tag => EditorGUILayout.TextField(tag)
+                    );
+                }
                 return temp;
             }
 

--- a/Assets/Plugins/Editor/Uplift/Windows/UpfileEditor.cs
+++ b/Assets/Plugins/Editor/Uplift/Windows/UpfileEditor.cs
@@ -129,10 +129,22 @@ namespace Uplift.Windows
         
         private Repository RepositoryField(Repository repository) 
         {
-            // FIXME: As we only support FileRepository for now, the cast is automatic
-            FileRepository temp = (FileRepository) repository;
-            temp.Path = EditorGUILayout.TextField("Path to file repository:", temp.Path);
-            return temp;
+            if(repository is FileRepository)
+            {
+                FileRepository temp = (FileRepository) repository;
+                temp.Path = EditorGUILayout.TextField("Path to file repository:", temp.Path);
+                return temp;
+            }
+
+            if(repository is GithubRepository)
+            {
+                GithubRepository temp = (GithubRepository) repository;
+                temp.Url = EditorGUILayout.TextField("Url of github repository", temp.Url);
+                return temp;
+            }
+
+            EditorGUILayout.HelpBox(string.Format("The repository {0} is not a known type of repository!"), MessageType.Error);
+            return repository;
         }
 
         private PathConfiguration PathField(string label, PathConfiguration path)


### PR DESCRIPTION
The Edit Upfile window was failing because of the lack of support for the new GithubRepository. This fixes it by

- adding support for GithubRepositories
- handling unknown cases