### PR TITLE
Change package~name to package-name

### DIFF
--- a/Assets/Plugins/Editor/Uplift/Export/Exporter.cs
+++ b/Assets/Plugins/Editor/Uplift/Export/Exporter.cs
@@ -68,7 +68,7 @@ namespace Uplift.Export
             }
 
             // Calculate package file basename
-            string packageBasename = string.Format("{0}~{1}", exportSpec.packageName, exportSpec.packageVersion);
+            string packageBasename = string.Format("{0}-{1}", exportSpec.packageName, exportSpec.packageVersion);
 
             // Create Target Directory
             if(!Directory.Exists(exportSpec.targetDir))


### PR DESCRIPTION
Github does not support packages named with a '~' which causes a few
issues, notably while uploading assets named this way and trying to
detect if it has already been released.