### PR TITLE
Fix lose and minimal version requirement merge

### DIFF
--- a/Assets/Plugins/Editor/Uplift/Common/VersionRequirements.cs
+++ b/Assets/Plugins/Editor/Uplift/Common/VersionRequirements.cs
@@ -232,6 +232,7 @@ namespace Uplift.Common
             else if (other is LoseVersionRequirement)
             {
                 if (minimal <= (other as LoseVersionRequirement).stub) return other;
+                if ((other as LoseVersionRequirement).IsMetBy(minimal)) return this;
             }
             else if (other is BoundedVersionRequirement)
             {

--- a/Assets/Plugins/Editor/Uplift/Testing/UnitTesting/VersionRequirementTest.cs
+++ b/Assets/Plugins/Editor/Uplift/Testing/UnitTesting/VersionRequirementTest.cs
@@ -137,6 +137,10 @@ namespace Uplift.Testing.Unit
                 loseRequirement = new LoseVersionRequirement("1.1");
                 Assert.AreSame(requirement.RestrictTo(loseRequirement), loseRequirement);
 
+                // When less detailed (1)
+                loseRequirement = new LoseVersionRequirement("1");
+                Assert.AreSame(requirement.RestrictTo(loseRequirement), requirement);
+
                 // When lesser (0.9)
                 loseRequirement = new LoseVersionRequirement("0.9");
                 Assert.Throws<IncompatibleRequirementException>(
@@ -226,6 +230,10 @@ namespace Uplift.Testing.Unit
                         requirement.RestrictTo(minimalRequirement);
                     }
                 );
+
+                // When more specific 1.0.4+
+                minimalRequirement = new MinimalVersionRequirement("1.0.4");
+                Assert.AreSame(requirement.RestrictTo(minimalRequirement), minimalRequirement);
 
                 // When lesser (0.9+)
                 minimalRequirement = new MinimalVersionRequirement("0.9");


### PR DESCRIPTION
In specifc scenarii (such as merging 0.9 and 0.9.4+) the requirements were not properly merged event though they are clearly compatible. This addresses it by adding this scenario to the MinimalVersionRequirement.RestrictTo(...)`.