### PR TITLE
Refactor ExportPackage definition

### DIFF
--- a/Assets/Plugins/Editor/Uplift/Export/Exporter.cs
+++ b/Assets/Plugins/Editor/Uplift/Export/Exporter.cs
@@ -45,7 +45,7 @@ namespace Uplift.Export
             // Prepare list of entries to export
             var exportEntries = new List<string>();
 
-            for(int i=0; i<exportSpec.paths.Length;i++)
+            for(int i = 0; i < exportSpec.paths.Length; i++)
             {
 
                 string path = exportSpec.paths[i];
@@ -146,7 +146,7 @@ namespace Uplift.Export
 
             Debug.LogFormat("{0} Package Export Specification(s) found. Preparing for export.", guids.Length);
 
-            for(int i=0; i<guids.Length;i++)
+            for(int i = 0; i < guids.Length; i++)
             {
 
                 string packageExportPath = AssetDatabase.GUIDToAssetPath(guids[i]);

--- a/Assets/Plugins/Editor/Uplift/Export/Exporter.cs
+++ b/Assets/Plugins/Editor/Uplift/Export/Exporter.cs
@@ -45,10 +45,10 @@ namespace Uplift.Export
             // Prepare list of entries to export
             var exportEntries = new List<string>();
 
-            for(int i = 0; i < exportSpec.paths.Length; i++)
+            for(int i = 0; i < exportSpec.pathsToExport.Length; i++)
             {
 
-                string path = exportSpec.paths[i];
+                string path = exportSpec.pathsToExport[i];
 
                 if(System.IO.File.Exists(path))
                 {
@@ -99,14 +99,14 @@ namespace Uplift.Export
             XmlSerializer serializer = new XmlSerializer(typeof(Upset));
 
             Upset template;
-            if(string.IsNullOrEmpty(exportSpec.templateUpsetPath))
+            if(string.IsNullOrEmpty(exportSpec.templateUpsetFile))
             {
                 Debug.LogWarning("No template Upset specified, dependencies and configuration will not follow through");
                 template = new Upset();
             }
             else
             {
-                using (FileStream fs = new FileStream(exportSpec.templateUpsetPath, FileMode.Open))
+                using (FileStream fs = new FileStream(exportSpec.templateUpsetFile, FileMode.Open))
                 {
                     template = serializer.Deserialize(fs) as Upset;
                 }

--- a/Assets/Plugins/Editor/Uplift/Export/Exporter.cs
+++ b/Assets/Plugins/Editor/Uplift/Export/Exporter.cs
@@ -99,14 +99,14 @@ namespace Uplift.Export
             XmlSerializer serializer = new XmlSerializer(typeof(Upset));
 
             Upset template;
-            if(string.IsNullOrEmpty(exportSpec.TemplateUpsetPath))
+            if(string.IsNullOrEmpty(exportSpec.templateUpsetPath))
             {
                 Debug.LogWarning("No template Upset specified, dependencies and configuration will not follow through");
                 template = new Upset();
             }
             else
             {
-                using (FileStream fs = new FileStream(exportSpec.TemplateUpsetPath, FileMode.Open))
+                using (FileStream fs = new FileStream(exportSpec.templateUpsetPath, FileMode.Open))
                 {
                     template = serializer.Deserialize(fs) as Upset;
                 }

--- a/Assets/Plugins/Editor/Uplift/Export/PackageExportData.cs
+++ b/Assets/Plugins/Editor/Uplift/Export/PackageExportData.cs
@@ -25,8 +25,6 @@
 using UnityEngine;
 using UnityEditor;
 using System;
-using Object = UnityEngine.Object;
-using Uplift.Schemas;
 
 namespace Uplift.Export
 {

--- a/Assets/Plugins/Editor/Uplift/Export/PackageExportData.cs
+++ b/Assets/Plugins/Editor/Uplift/Export/PackageExportData.cs
@@ -39,8 +39,8 @@ namespace Uplift.Export
         public  string    packageVersion  =  "";
         public  string    license         =  "";
         public  string    targetDir       =  "target";
-        public string[] paths       = new string[0];
-        public string templateUpsetPath = "";
+        public string[] pathsToExport       = new string[0];
+        public string templateUpsetFile = "";
 
         public object Clone()
         {

--- a/Assets/Plugins/Editor/Uplift/Export/PackageExportData.cs
+++ b/Assets/Plugins/Editor/Uplift/Export/PackageExportData.cs
@@ -26,6 +26,7 @@ using UnityEngine;
 using UnityEditor;
 using System;
 using Object = UnityEngine.Object;
+using Uplift.Schemas;
 
 namespace Uplift.Export
 {
@@ -34,58 +35,12 @@ namespace Uplift.Export
 #endif
     class PackageExportData : ScriptableObject, ICloneable
     {
-
-        [Header("Basic Package Information")]
         public  string    packageName     =  "";
         public  string    packageVersion  =  "";
         public  string    license         =  "";
-        public  Object    templateUpsetFile   = new Object();
-
-        [Header("Paths")]
-        public  Object[]  pathsToExport   =  new Object[0];
-
-        [Header("Export Settings")]
         public  string    targetDir       =  "target";
-
-        protected string[] rawPaths       = new string[0];
-
-        public string[] paths
-        {
-            get { return PathsToStringArray(); }
-            set
-            {
-                rawPaths = value;
-            }
-        }
-
-        public string TemplateUpsetPath
-        {
-            get
-            {
-                if(templateUpsetFile == null)
-                {
-                    return null;
-                }
-                return AssetDatabase.GetAssetPath(templateUpsetFile);
-            }
-        }
-
-        protected string[] PathsToStringArray()
-        {
-            string[] result = new string[pathsToExport.Length + rawPaths.Length];
-
-            for(int i=0; i<pathsToExport.Length;i++)
-            {
-                result[i] = AssetDatabase.GetAssetPath(pathsToExport[i]);
-            }
-
-            for(int i=0; i<rawPaths.Length;i++)
-            {
-                result[pathsToExport.Length + i] = rawPaths[i];
-            }
-
-            return result;
-        }
+        public string[] paths       = new string[0];
+        public string templateUpsetPath = "";
 
         public object Clone()
         {

--- a/Assets/Plugins/Editor/Uplift/Export/PackageExportDataInspector.cs
+++ b/Assets/Plugins/Editor/Uplift/Export/PackageExportDataInspector.cs
@@ -1,0 +1,79 @@
+using UnityEditor;
+using UnityEngine;
+using System;
+using System.Collections.Generic;
+using Object = UnityEngine.Object;
+
+namespace Uplift.Export
+{
+    [CustomEditor(typeof(PackageExportData))]
+    public class PackageExportDataInspector : Editor
+    {
+        private PackageExportData packageExportData;
+        private bool showPaths = true;
+
+        public void OnEnable()
+        {
+            packageExportData = (PackageExportData)target;
+            if(packageExportData.paths == null)
+                packageExportData.paths = new string[0];
+        }
+
+        public override void OnInspectorGUI()
+        {
+            EditorGUILayout.LabelField("Basic Package Information", EditorStyles.boldLabel);
+            packageExportData.packageName  = EditorGUILayout.TextField("Package name", packageExportData.packageName);
+            packageExportData.packageVersion  = EditorGUILayout.TextField("Package version", packageExportData.packageVersion);
+            packageExportData.license  = EditorGUILayout.TextField("License", packageExportData.license);
+            
+            EditorGUILayout.Separator();
+            EditorGUILayout.LabelField("Additional Package Information", EditorStyles.boldLabel);
+            EditorGUILayout.HelpBox("The template upset file is used to get the dependencies and the configuration of the package", MessageType.Info);
+            packageExportData.templateUpsetPath = AssetDatabase.GetAssetPath(
+                EditorGUILayout.ObjectField(
+                    "Template Upset file",
+                    AssetDatabase.LoadMainAssetAtPath(packageExportData.templateUpsetPath),
+                    typeof(UnityEngine.Object),
+                    false
+                )
+            );
+
+            EditorGUILayout.Separator();
+            EditorGUILayout.LabelField("Export Settings", EditorStyles.boldLabel);
+            packageExportData.targetDir = EditorGUILayout.TextField("Build destination directory", packageExportData.targetDir);
+            showPaths = EditorGUILayout.Foldout(showPaths, "Paths to export");
+            if(showPaths)
+            {
+                EditorGUI.indentLevel += 1;
+                for(int i = 0; i < packageExportData.paths.Length; i++)
+                {
+                    EditorGUILayout.BeginHorizontal();
+                    packageExportData.paths[i] = AssetDatabase.GetAssetPath(
+                        EditorGUILayout.ObjectField(
+                            "Item to export",
+                            AssetDatabase.LoadMainAssetAtPath(packageExportData.paths[i]),
+                            typeof(UnityEngine.Object),
+                            false
+                        )
+                    );
+                    if(GUILayout.Button("X", GUILayout.Width(20.0f)))
+                    {
+                        var tempPaths = new List<string>(packageExportData.paths);
+                        tempPaths.RemoveAt(i);
+                        packageExportData.paths = tempPaths.ToArray();
+                        EditorUtility.SetDirty(packageExportData);
+                    }
+                    EditorGUILayout.EndHorizontal();
+                }
+                EditorGUI.indentLevel -= 1;
+                if(GUILayout.Button("+"))
+                {
+                    Array.Resize<string>(ref packageExportData.paths, packageExportData.paths.Length + 1);
+                    EditorUtility.SetDirty(packageExportData);
+                }
+            }
+
+            EditorUtility.SetDirty(packageExportData);
+        }
+    }
+}

--- a/Assets/Plugins/Editor/Uplift/Export/PackageExportDataInspector.cs
+++ b/Assets/Plugins/Editor/Uplift/Export/PackageExportDataInspector.cs
@@ -10,13 +10,13 @@ namespace Uplift.Export
     public class PackageExportDataInspector : Editor
     {
         private PackageExportData packageExportData;
-        private bool showPaths = true;
+        private bool showPathspathsToExport = true;
 
         public void OnEnable()
         {
             packageExportData = (PackageExportData)target;
-            if(packageExportData.paths == null)
-                packageExportData.paths = new string[0];
+            if(packageExportData.pathsToExport == null)
+                packageExportData.pathsToExport = new string[0];
         }
 
         public override void OnInspectorGUI()
@@ -29,10 +29,10 @@ namespace Uplift.Export
             EditorGUILayout.Separator();
             EditorGUILayout.LabelField("Additional Package Information", EditorStyles.boldLabel);
             EditorGUILayout.HelpBox("The template upset file is used to get the dependencies and the configuration of the package", MessageType.Info);
-            packageExportData.templateUpsetPath = AssetDatabase.GetAssetPath(
+            packageExportData.templateUpsetFile = AssetDatabase.GetAssetPath(
                 EditorGUILayout.ObjectField(
                     "Template Upset file",
-                    AssetDatabase.LoadMainAssetAtPath(packageExportData.templateUpsetPath),
+                    AssetDatabase.LoadMainAssetAtPath(packageExportData.templateUpsetFile),
                     typeof(UnityEngine.Object),
                     false
                 )
@@ -41,26 +41,26 @@ namespace Uplift.Export
             EditorGUILayout.Separator();
             EditorGUILayout.LabelField("Export Settings", EditorStyles.boldLabel);
             packageExportData.targetDir = EditorGUILayout.TextField("Build destination directory", packageExportData.targetDir);
-            showPaths = EditorGUILayout.Foldout(showPaths, "Paths to export");
-            if(showPaths)
+            showPathspathsToExport = EditorGUILayout.Foldout(showPathspathsToExport, "Paths to export");
+            if(showPathspathsToExport)
             {
                 EditorGUI.indentLevel += 1;
-                for(int i = 0; i < packageExportData.paths.Length; i++)
+                for(int i = 0; i < packageExportData.pathsToExport.Length; i++)
                 {
                     EditorGUILayout.BeginHorizontal();
-                    packageExportData.paths[i] = AssetDatabase.GetAssetPath(
+                    packageExportData.pathsToExport[i] = AssetDatabase.GetAssetPath(
                         EditorGUILayout.ObjectField(
                             "Item to export",
-                            AssetDatabase.LoadMainAssetAtPath(packageExportData.paths[i]),
+                            AssetDatabase.LoadMainAssetAtPath(packageExportData.pathsToExport[i]),
                             typeof(UnityEngine.Object),
                             false
                         )
                     );
                     if(GUILayout.Button("X", GUILayout.Width(20.0f)))
                     {
-                        var tempPaths = new List<string>(packageExportData.paths);
-                        tempPaths.RemoveAt(i);
-                        packageExportData.paths = tempPaths.ToArray();
+                        var tempPathspathsToExport = new List<string>(packageExportData.pathsToExport);
+                        tempPathspathsToExport.RemoveAt(i);
+                        packageExportData.pathsToExport = tempPathspathsToExport.ToArray();
                         EditorUtility.SetDirty(packageExportData);
                     }
                     EditorGUILayout.EndHorizontal();
@@ -68,7 +68,7 @@ namespace Uplift.Export
                 EditorGUI.indentLevel -= 1;
                 if(GUILayout.Button("+"))
                 {
-                    Array.Resize<string>(ref packageExportData.paths, packageExportData.paths.Length + 1);
+                    Array.Resize<string>(ref packageExportData.pathsToExport, packageExportData.pathsToExport.Length + 1);
                     EditorUtility.SetDirty(packageExportData);
                 }
             }

--- a/Assets/Plugins/Editor/Uplift/Export/PackageExportDataInspector.cs.meta
+++ b/Assets/Plugins/Editor/Uplift/Export/PackageExportDataInspector.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 7df47205af8740c4986b261bf0edb150
+timeCreated: 1515087051
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Editor/Uplift/Windows/ExporterWindow.cs
+++ b/Assets/Plugins/Editor/Uplift/Windows/ExporterWindow.cs
@@ -62,7 +62,7 @@ namespace Uplift.Windows
                 };
 
                 potentialPackages[i].exportSpec = new PackageExportData() {
-                    paths = new string[]{path},
+                    pathsToExport = new string[]{path},
                     packageName = System.IO.Path.GetFileName(path),
                     packageVersion = "0.0.1",
                     license = "Undefined"
@@ -81,9 +81,9 @@ namespace Uplift.Windows
             for(int i = 0; i < potentialPackages.Length; i++)
             {
 #if !UNITY_5_5_OR_NEWER
-                expanded[i] = EditorGUILayout.Foldout(expanded[i], potentialPackages[i].exportSpec.paths[0]);
+                expanded[i] = EditorGUILayout.Foldout(expanded[i], potentialPackages[i].exportSpec.pathsToExport[0]);
 #else
-                expanded[i] = EditorGUILayout.Foldout(expanded[i], potentialPackages[i].exportSpec.paths[0], true);
+                expanded[i] = EditorGUILayout.Foldout(expanded[i], potentialPackages[i].exportSpec.pathsToExport[0], true);
 #endif
                 if (expanded[i])
                 {


### PR DESCRIPTION
The main goal of this is to clean the PackageExportData to separate the display of the data from the actual logic, in a backwards compatible way.

Besides cleaning, the goal of this is to enable:
- getting rid of the template Upset and allow dependency and configuration edition directly
- UI cleanup