### PR TITLE
Log current Uplift version on Initialize

### DIFF
--- a/Assets/Plugins/Editor/Uplift/Initialize.cs
+++ b/Assets/Plugins/Editor/Uplift/Initialize.cs
@@ -36,7 +36,7 @@ namespace Uplift
     {
         static Initialize()
         {
-            Debug.Log("Upfile loading...");
+            Debug.Log("Using Uplift version " + About.Version);
             if (!Upfile.CheckForUpfile())
             {
                 Debug.Log("No Upfile was found at the root of your project, Uplift created a sample one for you to start working on");


### PR DESCRIPTION
Instead of logging `Upfile loading...` which is not that nice, log the used version of Uplift for better understanding.