### PR TITLE
Fix: Better optional parameter parsing

### DIFF
--- a/Assets/Plugins/Editor/Uplift/Common/VersionRequirements.cs
+++ b/Assets/Plugins/Editor/Uplift/Common/VersionRequirements.cs
@@ -191,7 +191,7 @@ namespace Uplift.Common
     {
         public static bool IsMetBy(this IVersionRequirement requirement, string version)
         {
-            return requirement.IsMetBy(VersionParser.ParseVersion(version));
+            return requirement.IsMetBy(VersionParser.ParseIncompleteVersion(version));
         }
     }
 

--- a/Assets/Plugins/Editor/Uplift/UpliftManager.cs
+++ b/Assets/Plugins/Editor/Uplift/UpliftManager.cs
@@ -369,6 +369,7 @@ namespace Uplift
                     }
                     else
                     {
+                        UnityEngine.Debug.LogError("Could not find a repository while loading lockfile for " + match.Groups[1].Value);
                         installableList.Add(new PackageRepo
                         {
                             Package = new Upset 


### PR DESCRIPTION
When validating dependencies, the IVersionRequirement was not parsing the string completly (ie omitting the optional field in the version), resulting in improper validation.

This fixes the checks, and add better message in the situation where this failure appeared.