### PR TITLE
Introduce Range version requirement

### DIFF
--- a/Assets/Plugins/Editor/Uplift/Common/VersionParser.cs
+++ b/Assets/Plugins/Editor/Uplift/Common/VersionParser.cs
@@ -36,6 +36,11 @@ namespace Uplift.Common
             {
                 return new NoRequirement();
             }
+            else if (requirement.Contains(","))
+            {
+                string[] parts = requirement.Split(',');
+                return new RangeVersionRequirement(parts[0], parts[1]);
+            }
             else if (requirement.EndsWith("!"))
             {
                 return new ExactVersionRequirement(requirement.TrimEnd('!'));

--- a/Assets/Plugins/Editor/Uplift/Common/VersionParser.cs
+++ b/Assets/Plugins/Editor/Uplift/Common/VersionParser.cs
@@ -39,7 +39,8 @@ namespace Uplift.Common
             else if (requirement.Contains(","))
             {
                 string[] parts = requirement.Split(',');
-                return new RangeVersionRequirement(parts[0], parts[1]);
+                if(parts.Length == 2)
+                    return new RangeVersionRequirement(parts[0], parts[1]);
             }
             else if (requirement.EndsWith("!"))
             {

--- a/Assets/Plugins/Editor/Uplift/Common/VersionRequirements.cs
+++ b/Assets/Plugins/Editor/Uplift/Common/VersionRequirements.cs
@@ -282,7 +282,7 @@ namespace Uplift.Common
         public override IVersionRequirement RestrictTo(IVersionRequirement other) {
             if(other is LoseVersionRequirement)
             {
-                return other.RestrictTo(this);
+                return (other as LoseVersionRequirement).RestrictTo(this as BoundedVersionRequirement);
             }
             return base.RestrictTo(other);
         }
@@ -322,8 +322,21 @@ namespace Uplift.Common
             else if(other is RangeVersionRequirement)
             {
                 var otherRange = other as RangeVersionRequirement;
+                // self include other?
                 if (IsMetBy(otherRange.lower) && IsMetBy(otherRange.upper)) return other;
+                // other include self?
                 if (other.IsMetBy(lower) && other.IsMetBy(upper)) return this;
+                // They are overlapping or not intersecting
+                // overlap top?
+                if (IsMetBy(otherRange.lower) && other.IsMetBy(upper)) return new RangeVersionRequirement(
+                    otherRange.lower,
+                    this.upper
+                );
+                // overlap bottom?
+                if (IsMetBy(otherRange.upper) && other.IsMetBy(lower)) return new RangeVersionRequirement(
+                    this.lower,
+                    otherRange.upper
+                );
             }
             else if(other is ExactVersionRequirement)
             {

--- a/Assets/Plugins/Editor/Uplift/Common/VersionRequirements.cs
+++ b/Assets/Plugins/Editor/Uplift/Common/VersionRequirements.cs
@@ -229,14 +229,12 @@ namespace Uplift.Common
             {
                 return minimal >= (other as MinimalVersionRequirement).minimal ? this : other;
             }
-            else if (other is LoseVersionRequirement)
+            else if (other is RangeVersionRequirement)
             {
-                if (minimal <= (other as LoseVersionRequirement).stub) return other;
-                if ((other as LoseVersionRequirement).IsMetBy(minimal)) return this;
-            }
-            else if (other is BoundedVersionRequirement)
-            {
-                if (minimal <= (other as BoundedVersionRequirement).lowerBound) return other;
+                if (minimal <= (other as RangeVersionRequirement).lower) return other;
+                if (other.IsMetBy(minimal)) return new RangeVersionRequirement(
+                    minimal,
+                    (other as RangeVersionRequirement).upper);
             }
             else if (other is ExactVersionRequirement)
             {
@@ -252,79 +250,80 @@ namespace Uplift.Common
     }
 
     // When stub is specified
-    public class LoseVersionRequirement : IVersionRequirement
+    public class LoseVersionRequirement : RangeVersionRequirement
     {
-        public Version stub;
-        private Version limit;
-
         public LoseVersionRequirement(string stub) : this(VersionParser.ParseIncompleteVersion(stub)) { }
-        public LoseVersionRequirement(Version stub)
-        {
-            this.stub = stub;
-            limit = stub.Next;
+        public LoseVersionRequirement(Version stub) : base(stub, stub.Next) { }
+
+        public override IVersionRequirement RestrictTo(IVersionRequirement other) {
+            if(other is BoundedVersionRequirement)
+            {
+                if(IsMetBy((other as BoundedVersionRequirement).lower)) return other;
+            }
+            return base.RestrictTo(other);
         }
 
-        public bool IsMetBy(Version version)
+        public override string ToString()
         {
-            return version >= stub && version < limit;
+            return lower.ToString();
+        }
+    }
+
+    public class BoundedVersionRequirement : RangeVersionRequirement
+    {
+        public BoundedVersionRequirement(string lowerBound) : this(VersionParser.ParseIncompleteVersion(lowerBound)) { }
+        public BoundedVersionRequirement(Version lowerBound) : base(lowerBound, lowerBound.Next) { }
+
+        public override bool IsMetBy(Version version)
+        {
+            return version > lower && version < upper;
         }
 
-        public IVersionRequirement RestrictTo(IVersionRequirement other)
+        public override IVersionRequirement RestrictTo(IVersionRequirement other) {
+            if(other is LoseVersionRequirement)
+            {
+                return other.RestrictTo(this);
+            }
+            return base.RestrictTo(other);
+        }
+
+        public override string ToString()
+        {
+            return lower.ToString() + ".*";
+        }
+    }
+
+    public class RangeVersionRequirement : IVersionRequirement
+    {
+        public Version lower;
+        public Version upper;
+
+        public RangeVersionRequirement(string lower, string upper) : this(
+            VersionParser.ParseIncompleteVersion(lower),
+            VersionParser.ParseIncompleteVersion(upper)) { }
+        public RangeVersionRequirement(Version lower, Version upper)
+        {
+            if(lower >= upper) throw new ArgumentException("Upper version of a RangeVersionRequirement cannot be inferior to its lower version");
+            this.lower = lower;
+            this.upper = upper;
+        }
+
+        public virtual bool IsMetBy(Version version)
+        {
+            return version >= lower && version < upper;
+        }
+
+        public virtual IVersionRequirement RestrictTo(IVersionRequirement other)
         {
             if (other is NoRequirement || other is MinimalVersionRequirement)
             {
                 return other.RestrictTo(this);
-            }
-            else if (other is LoseVersionRequirement)
-            {
-                if (IsMetBy((other as LoseVersionRequirement).stub)) return other;
-                if ((other as LoseVersionRequirement).IsMetBy(stub)) return this;
-            }
-            else if(other is BoundedVersionRequirement)
-            {
-                if (IsMetBy((other as BoundedVersionRequirement).lowerBound)) return other;
-                if ((other as BoundedVersionRequirement).IsMetBy(stub)) return this;
-            }
-            else if(other is ExactVersionRequirement)
-            {
-                if (IsMetBy((other as ExactVersionRequirement).expected)) return other;
-            }
-            throw new IncompatibleRequirementException(this, other);
-        }
-
-        public override string ToString()
-        {
-            return stub.ToString();
-        }
-    }
-
-    public class BoundedVersionRequirement : IVersionRequirement
-    {
-        public Version lowerBound;
-        private Version upperBound;
-
-        public BoundedVersionRequirement(string lowerBound) : this(VersionParser.ParseIncompleteVersion(lowerBound)) { }
-        public BoundedVersionRequirement(Version lowerBound)
-        {
-            this.lowerBound = lowerBound;
-            upperBound = lowerBound.Next;
-        }
-
-        public bool IsMetBy(Version version)
-        {
-            return version > lowerBound && version < upperBound;
-        }
-
-        public IVersionRequirement RestrictTo(IVersionRequirement other)
-        {
-            if (other is NoRequirement || other is MinimalVersionRequirement || other is LoseVersionRequirement)
-            {
-                return other.RestrictTo(this);
             }   
-            else if(other is BoundedVersionRequirement)
+            else if(other is RangeVersionRequirement)
             {
-                if (IsMetBy((other as BoundedVersionRequirement).lowerBound)) return other;
-                if ((other as BoundedVersionRequirement).IsMetBy(lowerBound)) return this;
+                var otherRange = other as RangeVersionRequirement;
+                if (IsMetBy(otherRange.lower) && IsMetBy(otherRange.upper)) return other;
+                if (other.IsMetBy(lower) && other.IsMetBy(upper)) return this;
             }
             else if(other is ExactVersionRequirement)
             {
@@ -335,7 +334,20 @@ namespace Uplift.Common
 
         public override string ToString()
         {
-            return lowerBound.ToString() + ".*";
+            return lower.ToString() + "," + upper.ToString();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if(!(obj is RangeVersionRequirement)) return false;
+            var otherRange = obj as RangeVersionRequirement;
+
+            return upper == otherRange.upper && lower == otherRange.lower;
+        }
+
+        public override int GetHashCode()
+        {
+            return lower.GetHashCode() & upper.GetHashCode();
         }
     }
 

--- a/Assets/Plugins/Editor/Uplift/Testing/UnitTesting/VersionRequirementTest.cs
+++ b/Assets/Plugins/Editor/Uplift/Testing/UnitTesting/VersionRequirementTest.cs
@@ -208,6 +208,7 @@ namespace Uplift.Testing.Unit
                 Assert.IsTrue(requirement.IsMetBy("1.0"));
                 Assert.IsTrue(requirement.IsMetBy("1.0.0"));
                 Assert.IsTrue(requirement.IsMetBy("1.0.1"));
+                Assert.IsFalse(requirement.IsMetBy("1.1.0"));
                 Assert.IsFalse(requirement.IsMetBy("2.0.0"));
             }
 

--- a/Assets/Plugins/Editor/Uplift/Testing/UnitTesting/VersionRequirementTest.cs
+++ b/Assets/Plugins/Editor/Uplift/Testing/UnitTesting/VersionRequirementTest.cs
@@ -139,7 +139,8 @@ namespace Uplift.Testing.Unit
 
                 // When less detailed (1)
                 loseRequirement = new LoseVersionRequirement("1");
-                Assert.AreSame(requirement.RestrictTo(loseRequirement), requirement);
+                IVersionRequirement targetRequirement = new RangeVersionRequirement("1.0", "2");
+                Assert.AreEqual(requirement.RestrictTo(loseRequirement), targetRequirement);
 
                 // When lesser (0.9)
                 loseRequirement = new LoseVersionRequirement("0.9");
@@ -234,7 +235,9 @@ namespace Uplift.Testing.Unit
 
                 // When more specific 1.0.4+
                 minimalRequirement = new MinimalVersionRequirement("1.0.4");
-                Assert.AreSame(requirement.RestrictTo(minimalRequirement), minimalRequirement);
+                // Restricts to a new, more restrictive range
+                IVersionRequirement targetRequirement = new RangeVersionRequirement("1.0.4", "1.1");
+                Assert.AreEqual(requirement.RestrictTo(minimalRequirement), targetRequirement);
 
                 // When lesser (0.9+)
                 minimalRequirement = new MinimalVersionRequirement("0.9");

--- a/Assets/Plugins/Editor/Uplift/Testing/UnitTesting/VersionRequirementTest.cs
+++ b/Assets/Plugins/Editor/Uplift/Testing/UnitTesting/VersionRequirementTest.cs
@@ -461,6 +461,169 @@ namespace Uplift.Testing.Unit
         }
 
         [TestFixture]
+        class RangeVersionRequirementTest
+        {
+            IVersionRequirement requirement;
+
+            [OneTimeSetUp]
+            protected void Given()
+            {
+                // 1.5,3.5
+                requirement = new RangeVersionRequirement("1.5", "3.5");
+            }
+
+            [Test]
+            public void IsMetBy()
+            {
+                Assert.IsFalse(requirement.IsMetBy("0.0.0"));
+                Assert.IsFalse(requirement.IsMetBy("1.4.9"));
+                Assert.IsTrue(requirement.IsMetBy("1.5"));
+                Assert.IsTrue(requirement.IsMetBy("1.5.1"));
+                Assert.IsTrue(requirement.IsMetBy("1.6"));
+                Assert.IsTrue(requirement.IsMetBy("1.6.1"));
+                Assert.IsTrue(requirement.IsMetBy("2"));
+                Assert.IsTrue(requirement.IsMetBy("2.9"));
+                Assert.IsTrue(requirement.IsMetBy("2.9.9"));
+                Assert.IsFalse(requirement.IsMetBy("3.5"));
+                Assert.IsFalse(requirement.IsMetBy("3.5.0"));
+            }
+
+            [Test]
+            public void ResrictToNoRequirement()
+            {
+                NoRequirement noRequirement = new NoRequirement();
+                Assert.AreSame(requirement.RestrictTo(noRequirement), requirement);
+            }
+
+            [Test]
+            public void ResrictToMinimalRequirement()
+            {
+                MinimalVersionRequirement minimalRequirement;
+                IVersionRequirement targetRequirement;
+                // When greater (4.0+)
+                minimalRequirement = new MinimalVersionRequirement("4.0");
+                Assert.Throws<IncompatibleRequirementException>(
+                    delegate
+                    {
+                        requirement.RestrictTo(minimalRequirement);
+                    }
+                );
+
+                // When in between (2.0+)
+                minimalRequirement = new MinimalVersionRequirement("2.0");
+                targetRequirement = new RangeVersionRequirement("2.0", "3.5");
+                Assert.AreEqual(requirement.RestrictTo(minimalRequirement), targetRequirement);
+
+                // When lesser (0.9+)
+                minimalRequirement = new MinimalVersionRequirement("0.9");
+                Assert.AreSame(requirement.RestrictTo(minimalRequirement), requirement);
+            }
+
+            [Test]
+            public void RestrictToLoseRequirement()
+            {
+                LoseVersionRequirement loseRequirement;
+                IVersionRequirement targetRequirement;
+                // When greater (4.0)
+                loseRequirement = new LoseVersionRequirement("4.0");
+                Assert.Throws<IncompatibleRequirementException>(
+                    delegate
+                    {
+                        requirement.RestrictTo(loseRequirement);
+                    }
+                );
+
+                // When in between (2.0)
+                loseRequirement = new LoseVersionRequirement("2.0");
+                Assert.AreEqual(requirement.RestrictTo(loseRequirement), loseRequirement);
+
+                // When lesser (0.9)
+                loseRequirement = new LoseVersionRequirement("0.9");
+                Assert.Throws<IncompatibleRequirementException>(
+                    delegate
+                    {
+                        requirement.RestrictTo(loseRequirement);
+                    }
+                );
+
+                // When overlapping bottom
+                loseRequirement = new LoseVersionRequirement("1");
+                targetRequirement = new RangeVersionRequirement("1.5", "2");
+                Assert.AreEqual(requirement.RestrictTo(loseRequirement), targetRequirement);
+
+                // When overlapping top
+                loseRequirement = new LoseVersionRequirement("3");
+                targetRequirement = new RangeVersionRequirement("3", "3.5");
+                Assert.AreEqual(requirement.RestrictTo(loseRequirement), targetRequirement);
+            }
+
+            [Test]
+            public void RestrictToBoundedRequirement()
+            {
+                BoundedVersionRequirement loseRequirement;
+                IVersionRequirement targetRequirement;
+                // When greater (4.0)
+                loseRequirement = new BoundedVersionRequirement("4.0.*");
+                Assert.Throws<IncompatibleRequirementException>(
+                    delegate
+                    {
+                        requirement.RestrictTo(loseRequirement);
+                    }
+                );
+
+                // When in between (2.0)
+                loseRequirement = new BoundedVersionRequirement("2.0.*");
+                Assert.AreEqual(requirement.RestrictTo(loseRequirement), loseRequirement);
+
+                // When lesser (0.9)
+                loseRequirement = new BoundedVersionRequirement("0.9.*");
+                Assert.Throws<IncompatibleRequirementException>(
+                    delegate
+                    {
+                        requirement.RestrictTo(loseRequirement);
+                    }
+                );
+
+                // When overlapping bottom
+                loseRequirement = new BoundedVersionRequirement("1.0");
+                targetRequirement = new RangeVersionRequirement("1.5", "2.0");
+                Assert.AreEqual(requirement.RestrictTo(loseRequirement), targetRequirement);
+
+                // When overlapping top
+                loseRequirement = new BoundedVersionRequirement("3.0");
+                targetRequirement = new RangeVersionRequirement("3.0", "3.5");
+                Assert.AreEqual(requirement.RestrictTo(loseRequirement), targetRequirement);
+            }
+
+            [Test]
+            public void RestrictToExactRequirement()
+            {
+                ExactVersionRequirement exactRequirement;
+                // When greater (3.5.1!)
+                exactRequirement = new ExactVersionRequirement("3.5.1");
+                Assert.Throws<IncompatibleRequirementException>(
+                    delegate
+                    {
+                        requirement.RestrictTo(exactRequirement);
+                    }
+                );
+
+                // When in between (2.0!)
+                exactRequirement = new ExactVersionRequirement("2.0");
+                Assert.AreSame(requirement.RestrictTo(exactRequirement), exactRequirement);
+
+                // When lesser (0.9.9!)
+                exactRequirement = new ExactVersionRequirement("0.9.9");
+                Assert.Throws<IncompatibleRequirementException>(
+                    delegate
+                    {
+                        requirement.RestrictTo(exactRequirement);
+                    }
+                );
+            }
+        }
+
+        [TestFixture]
         class ExactVersionRequirementTest
         {
             IVersionRequirement requirement;

--- a/Assets/Plugins/Editor/Uplift/Testing/UnitTesting/VersionTest.cs
+++ b/Assets/Plugins/Editor/Uplift/Testing/UnitTesting/VersionTest.cs
@@ -52,7 +52,7 @@ namespace Uplift.Testing.Unit
             {
                 IVersionRequirement parsed = VersionParser.ParseRequirement("1.2");
                 Assert.IsTrue(parsed is LoseVersionRequirement);
-                Assert.AreEqual((parsed as LoseVersionRequirement).stub, new Version { Major = 1, Minor = 2 });
+                Assert.AreEqual((parsed as LoseVersionRequirement).lower, new Version { Major = 1, Minor = 2 });
             }
 
             [Test]
@@ -60,7 +60,7 @@ namespace Uplift.Testing.Unit
             {
                 IVersionRequirement parsed = VersionParser.ParseRequirement("1.2.*");
                 Assert.IsTrue(parsed is BoundedVersionRequirement);
-                Assert.AreEqual((parsed as BoundedVersionRequirement).lowerBound, new Version { Major = 1, Minor = 2 });
+                Assert.AreEqual((parsed as BoundedVersionRequirement).lower, new Version { Major = 1, Minor = 2 });
             }
 
             [Test]

--- a/Assets/Plugins/Editor/Uplift/Testing/UnitTesting/VersionTest.cs
+++ b/Assets/Plugins/Editor/Uplift/Testing/UnitTesting/VersionTest.cs
@@ -72,6 +72,26 @@ namespace Uplift.Testing.Unit
             }
 
             [Test]
+            public void ParseRangeRequirement()
+            {
+                IVersionRequirement parsed = VersionParser.ParseRequirement("1.2,3.4");
+                Assert.IsTrue(parsed is RangeVersionRequirement);
+                Assert.AreEqual((parsed as RangeVersionRequirement).lower, new Version { Major = 1, Minor = 2 });
+                Assert.AreEqual((parsed as RangeVersionRequirement).upper, new Version { Major = 3, Minor = 4 });
+            }
+
+            [Test]
+            public void DoNotParseInvertedRangeRequirement()
+            {
+                Assert.Throws<System.ArgumentException>(
+                    delegate
+                    {
+                       VersionParser.ParseRequirement("3.4,1.2");
+                    }
+                );
+            }
+
+            [Test]
             public void DoNotParseWrongRequirement()
             {
                 // QUESTION: Should we not fail there?


### PR DESCRIPTION
This introduces the new `RangeVersionRequirement` which enables to define more precise syntax such as `Version="a,b"` with `a <= version < b`.

This new requirement enables other requirements that were considered incompatibles to be so.
This PR also fixes #66 by correctly merging LoseVersionRequirements and included MinimalVersionRequirement as a more restrictive RangeVersionRequirement.