### PR TITLE
Correct update package function to prevent error in First method

### DIFF
--- a/Assets/Plugins/Editor/Uplift/UpliftManager.cs
+++ b/Assets/Plugins/Editor/Uplift/UpliftManager.cs
@@ -670,7 +670,15 @@ namespace Uplift
 		{
 			NukePackage(package.PackageName);
 
+			// First or default returns the first DependencyDefinition which satistfies dep.Name == package.PackageName
+			// If no elements meets this condition a Default value for DependencyDefinition is returned which, for our implementation, is null. 
 			DependencyDefinition definition = Upfile.Instance().Dependencies.FirstOrDefault(dep => dep.Name == package.PackageName);
+
+			if (definition == null)
+			{
+				definition = new DependencyDefinition() { Name = package.PackageName, Version = package.PackageVersion };
+			}
+
 			InstallPackage(package, td, definition, true);
 		}
 

--- a/Assets/Plugins/Editor/Uplift/UpliftManager.cs
+++ b/Assets/Plugins/Editor/Uplift/UpliftManager.cs
@@ -22,6 +22,7 @@
  */
 // --- END LICENSE BLOCK ---
 
+using System;
 using System.IO;
 using System.Linq;
 using Uplift.Common;
@@ -473,6 +474,11 @@ namespace Uplift
 		// This should be contained using kinds of destinations.
 		private void InstallPackage(Upset package, TemporaryDirectory td, DependencyDefinition dependencyDefinition, bool updateLockfile = false)
 		{
+			if (dependencyDefinition == null)
+			{
+				throw new ArgumentNullException("Failed to install package " + package.PackageName + ". Dependency Definition is null.");
+			}
+
 			GitIgnorer VCSHandler = new GitIgnorer();
 
 			using (LogAggregator LA = LogAggregator.InUnity(
@@ -515,12 +521,12 @@ namespace Uplift
 
 				foreach (InstallSpecPath spec in specArray)
 				{
-					if (dependencyDefinition != null && dependencyDefinition.SkipInstall != null && dependencyDefinition.SkipInstall.Any(skip => skip.Type == spec.Type)) continue;
+					if (dependencyDefinition.SkipInstall != null && dependencyDefinition.SkipInstall.Any(skip => skip.Type == spec.Type)) continue;
 
 					var sourcePath = Uplift.Common.FileSystemUtil.JoinPaths(td.Path, spec.Path);
 
 					PathConfiguration PH = upfile.GetDestinationFor(spec);
-					if (dependencyDefinition != null && dependencyDefinition.OverrideDestination != null && dependencyDefinition.OverrideDestination.Any(over => over.Type == spec.Type))
+					if (dependencyDefinition.OverrideDestination != null && dependencyDefinition.OverrideDestination.Any(over => over.Type == spec.Type))
 					{
 						PH.Location = Uplift.Common.FileSystemUtil.MakePathOSFriendly(dependencyDefinition.OverrideDestination.First(over => over.Type == spec.Type).Location);
 					}

--- a/Assets/Plugins/Editor/Uplift/UpliftManager.cs
+++ b/Assets/Plugins/Editor/Uplift/UpliftManager.cs
@@ -515,12 +515,12 @@ namespace Uplift
 
 				foreach (InstallSpecPath spec in specArray)
 				{
-					if (dependencyDefinition.SkipInstall != null && dependencyDefinition.SkipInstall.Any(skip => skip.Type == spec.Type)) continue;
+					if (dependencyDefinition != null && dependencyDefinition.SkipInstall != null && dependencyDefinition.SkipInstall.Any(skip => skip.Type == spec.Type)) continue;
 
 					var sourcePath = Uplift.Common.FileSystemUtil.JoinPaths(td.Path, spec.Path);
 
 					PathConfiguration PH = upfile.GetDestinationFor(spec);
-					if (dependencyDefinition.OverrideDestination != null && dependencyDefinition.OverrideDestination.Any(over => over.Type == spec.Type))
+					if (dependencyDefinition != null && dependencyDefinition.OverrideDestination != null && dependencyDefinition.OverrideDestination.Any(over => over.Type == spec.Type))
 					{
 						PH.Location = Uplift.Common.FileSystemUtil.MakePathOSFriendly(dependencyDefinition.OverrideDestination.First(over => over.Type == spec.Type).Location);
 					}
@@ -670,7 +670,7 @@ namespace Uplift
 		{
 			NukePackage(package.PackageName);
 
-			DependencyDefinition definition = Upfile.Instance().Dependencies.First(dep => dep.Name == package.PackageName);
+			DependencyDefinition definition = Upfile.Instance().Dependencies.FirstOrDefault(dep => dep.Name == package.PackageName);
 			InstallPackage(package, td, definition, true);
 		}
 


### PR DESCRIPTION
There was an error happening sometimes when updating package : 
`System.InvalidOperationException: Operation is not valid due to the current state of the object`

It seemed to occurred when uplift tries to update a package which is not listed in the "UPFILE DEPENDENCIES" listed in Upfile.lock. Thus the search for the package definition failed. 

Small fix which solve problem while updating a package was to set the package definition to null in that case by using `FirstOrDefault` instead of `First` method. 

**NOTE :** This PR depends on [this PR](https://github.com/DragonBox/uplift/pull/71/commits)

I had a little trouble opening this pull request, but it should be fine by now.