### PR TITLE
Fix/lockfile/fix lockfile modifications when installing from lockfile

### DIFF
--- a/Assets/Plugins/Editor/Uplift/UpliftManager.cs
+++ b/Assets/Plugins/Editor/Uplift/UpliftManager.cs
@@ -91,8 +91,9 @@ namespace Uplift
 
 		public void InstallDependencies(InstallStrategy strategy = InstallStrategy.UPDATE_LOCKFILE)
 		{
-			PackageRepo[] targets = GetTargets(GetDependencySolver(), strategy);
-			InstallPackages(targets);
+			bool isNotOnlyLockFile = (strategy != InstallStrategy.ONLY_LOCKFILE);
+			PackageRepo[] targets = GetTargets(GetDependencySolver(), strategy, isNotOnlyLockFile);
+			InstallPackages(targets, isNotOnlyLockFile);
 		}
 
 		public DependencyState[] GetDependenciesState()
@@ -395,7 +396,7 @@ namespace Uplift
 			return result;
 		}
 
-		public void InstallPackages(PackageRepo[] targets)
+		public void InstallPackages(PackageRepo[] targets, bool allowPackagesToUpdate)
 		{
 			using (LogAggregator LA = LogAggregator.InUnity(
 				"Successfully installed dependencies ({0} actions were done)",
@@ -417,7 +418,7 @@ namespace Uplift
 				{
 					if (pr.Repository != null)
 					{
-						if (Upbring.Instance().InstalledPackage.Any(ip => ip.Name == pr.Package.PackageName))
+						if (allowPackagesToUpdate && Upbring.Instance().InstalledPackage.Any(ip => ip.Name == pr.Package.PackageName))
 						{
 							UpdatePackage(pr);
 						}

--- a/Assets/Plugins/Editor/Uplift/UpliftManager.cs
+++ b/Assets/Plugins/Editor/Uplift/UpliftManager.cs
@@ -28,6 +28,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using UnityEditor;
+using UnityEngine;
 using Uplift.Common;
 using Uplift.DependencyResolution;
 using Uplift.Packages;
@@ -91,9 +92,9 @@ namespace Uplift
 
 		public void InstallDependencies(InstallStrategy strategy = InstallStrategy.UPDATE_LOCKFILE)
 		{
-			bool isNotOnlyLockFile = (strategy != InstallStrategy.ONLY_LOCKFILE);
-			PackageRepo[] targets = GetTargets(GetDependencySolver(), strategy, isNotOnlyLockFile);
-			InstallPackages(targets, isNotOnlyLockFile);
+			bool canUpdatePackages = (strategy != InstallStrategy.ONLY_LOCKFILE);
+			PackageRepo[] targets = GetTargets(GetDependencySolver(), strategy, canUpdatePackages);
+			InstallPackages(targets, canUpdatePackages);
 		}
 
 		public DependencyState[] GetDependenciesState()

--- a/Assets/Plugins/Editor/Uplift/UpliftManager.cs
+++ b/Assets/Plugins/Editor/Uplift/UpliftManager.cs
@@ -91,8 +91,9 @@ namespace Uplift
 
 		public void InstallDependencies(InstallStrategy strategy = InstallStrategy.UPDATE_LOCKFILE)
 		{
+			PackageRepo[] targets = GetTargets(GetDependencySolver(), strategy);
+
 			bool canUpdatePackages = (strategy != InstallStrategy.ONLY_LOCKFILE);
-			PackageRepo[] targets = GetTargets(GetDependencySolver(), strategy, canUpdatePackages);
 			InstallPackages(targets, canUpdatePackages);
 		}
 

--- a/Assets/Plugins/Editor/Uplift/UpliftManager.cs
+++ b/Assets/Plugins/Editor/Uplift/UpliftManager.cs
@@ -28,7 +28,6 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using UnityEditor;
-using UnityEngine;
 using Uplift.Common;
 using Uplift.DependencyResolution;
 using Uplift.Packages;


### PR DESCRIPTION
In some cases, lockfile was modified when choosing option _"Install dependencies (as specified in lockfile)"_. This behavior was unexpected since we just want to read the lockfile and install dependencies specified in that file.

This problem was occurring because `UpdatePackage` method was called within `InstallPackages`.
This was solved by adding a new parameter `allowPackagesToUpdate` to `InstallPackages`.