### PR TITLE
Fix/lockfile/prevent editing of transitive dependency when installing from lockfile

### DIFF
--- a/Assets/Plugins/Editor/Uplift/Common/Cli.cs
+++ b/Assets/Plugins/Editor/Uplift/Common/Cli.cs
@@ -49,7 +49,7 @@ namespace Uplift.Common
 			string packageName = LastArgument();
 
 			PackageRepo pr = PackageList.Instance().GetLatestPackage(packageName);
-			UpliftManager.Instance().UpdatePackage(pr);
+			UpliftManager.Instance().UpdatePackage(pr, true);
 		}
 
 		public static void NukePackage()

--- a/Assets/Plugins/Editor/Uplift/Common/Cli.cs
+++ b/Assets/Plugins/Editor/Uplift/Common/Cli.cs
@@ -49,7 +49,7 @@ namespace Uplift.Common
 			string packageName = LastArgument();
 
 			PackageRepo pr = PackageList.Instance().GetLatestPackage(packageName);
-			UpliftManager.Instance().UpdatePackage(pr, true);
+			UpliftManager.Instance().UpdatePackage(pr, updateLockfile: true);
 		}
 
 		public static void NukePackage()

--- a/Assets/Plugins/Editor/Uplift/Export/Exporter.cs
+++ b/Assets/Plugins/Editor/Uplift/Export/Exporter.cs
@@ -26,6 +26,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Xml.Serialization;
 using System.Linq;
+using UnityEditor;
+using UnityEngine;
+using Uplift.Schemas;
 
 namespace Uplift.Export
 {

--- a/Assets/Plugins/Editor/Uplift/UpliftManager.cs
+++ b/Assets/Plugins/Editor/Uplift/UpliftManager.cs
@@ -423,7 +423,7 @@ namespace Uplift
 					{
 						if (Upbring.Instance().InstalledPackage.Any(ip => ip.Name == pr.Package.PackageName))
 						{
-							UpdatePackage(pr, updateLockfile);
+							UpdatePackage(pr, updateLockfile: updateLockfile);
 						}
 						else
 						{
@@ -696,7 +696,7 @@ namespace Uplift
 			InstallPackage(package, td, definition, updateLockfile);
 		}
 
-		public void UpdatePackage(PackageRepo newer, bool updateLockfile = true, bool updateDependencies = true)
+		public void UpdatePackage(PackageRepo newer, bool updateDependencies = true, bool updateLockfile = true)
 		{
 			InstalledPackage installed = Upbring.Instance().InstalledPackage.First(ip => ip.Name == newer.Package.PackageName);
 
@@ -727,8 +727,9 @@ namespace Uplift
 					if (Upbring.Instance().InstalledPackage.Any(ip => ip.Name == def.Name))
 					{
 						UpdatePackage(dependencyPR,
-									  updateLockfile: true,
-									  updateDependencies: false);
+									  updateDependencies: false,
+									  updateLockfile: true
+									  );
 					}
 					else
 					{

--- a/Assets/Plugins/Editor/Uplift/UpliftManager.cs
+++ b/Assets/Plugins/Editor/Uplift/UpliftManager.cs
@@ -728,7 +728,7 @@ namespace Uplift
 					{
 						UpdatePackage(dependencyPR,
 									  updateDependencies: false,
-									  updateLockfile: true
+									  updateLockfile: updateLockfile
 									  );
 					}
 					else
@@ -738,7 +738,7 @@ namespace Uplift
 							InstallPackage(dependencyPR.Package,
 										   td,
 										   def,
-										   updateLockfile: true);
+										   updateLockfile: updateLockfile);
 						}
 					}
 				}

--- a/Assets/Plugins/Editor/Uplift/UpliftManager.cs
+++ b/Assets/Plugins/Editor/Uplift/UpliftManager.cs
@@ -101,8 +101,8 @@ namespace Uplift
 		{
 			Upbring upbring = Upbring.Instance();
 			PackageRepo[] targets = GetTargets(GetDependencySolver(),
-											   InstallStrategy.UPDATE_LOCKFILE,
-											   updateLockfile: false);
+												InstallStrategy.UPDATE_LOCKFILE,
+												updateLockfile: false);
 
 			bool anyInstalled =
 						upbring.InstalledPackage != null &&
@@ -727,18 +727,18 @@ namespace Uplift
 					if (Upbring.Instance().InstalledPackage.Any(ip => ip.Name == def.Name))
 					{
 						UpdatePackage(dependencyPR,
-									  updateDependencies: false,
-									  updateLockfile: updateLockfile
-									  );
+										updateDependencies: false,
+										updateLockfile: updateLockfile
+										);
 					}
 					else
 					{
 						using (TemporaryDirectory td = dependencyPR.Repository.DownloadPackage(dependencyPR.Package))
 						{
 							InstallPackage(dependencyPR.Package,
-										   td,
-										   def,
-										   updateLockfile: updateLockfile);
+											td,
+											def,
+											updateLockfile: updateLockfile);
 						}
 					}
 				}

--- a/Assets/Plugins/Editor/Uplift/UpliftManager.cs
+++ b/Assets/Plugins/Editor/Uplift/UpliftManager.cs
@@ -101,8 +101,8 @@ namespace Uplift
 		{
 			Upbring upbring = Upbring.Instance();
 			PackageRepo[] targets = GetTargets(GetDependencySolver(),
-												InstallStrategy.UPDATE_LOCKFILE,
-												updateLockfile: false);
+											   InstallStrategy.UPDATE_LOCKFILE,
+											   updateLockfile: false);
 
 			bool anyInstalled =
 						upbring.InstalledPackage != null &&
@@ -727,18 +727,19 @@ namespace Uplift
 					if (Upbring.Instance().InstalledPackage.Any(ip => ip.Name == def.Name))
 					{
 						UpdatePackage(dependencyPR,
-										updateDependencies: false,
-										updateLockfile: updateLockfile
-										);
+									  updateDependencies: false,
+									  updateLockfile: updateLockfile
+									 );
 					}
 					else
 					{
 						using (TemporaryDirectory td = dependencyPR.Repository.DownloadPackage(dependencyPR.Package))
 						{
 							InstallPackage(dependencyPR.Package,
-											td,
-											def,
-											updateLockfile: updateLockfile);
+										   td,
+										   def,
+										   updateLockfile: updateLockfile
+										  );
 						}
 					}
 				}

--- a/Assets/Plugins/Editor/Uplift/UpliftManager.cs
+++ b/Assets/Plugins/Editor/Uplift/UpliftManager.cs
@@ -100,7 +100,9 @@ namespace Uplift
 		public DependencyState[] GetDependenciesState()
 		{
 			Upbring upbring = Upbring.Instance();
-			PackageRepo[] targets = GetTargets(GetDependencySolver(), InstallStrategy.UPDATE_LOCKFILE, false);
+			PackageRepo[] targets = GetTargets(GetDependencySolver(),
+											   InstallStrategy.UPDATE_LOCKFILE,
+											   updateLockfile: false);
 
 			bool anyInstalled =
 						upbring.InstalledPackage != null &&
@@ -397,7 +399,7 @@ namespace Uplift
 			return result;
 		}
 
-		public void InstallPackages(PackageRepo[] targets, bool updateLockfile)
+		public void InstallPackages(PackageRepo[] targets, bool updateLockfile = true)
 		{
 			using (LogAggregator LA = LogAggregator.InUnity(
 				"Successfully installed dependencies ({0} actions were done)",
@@ -478,7 +480,7 @@ namespace Uplift
 
 		//FIXME: This is super unsafe right now, as we can copy down into the FS.
 		// This should be contained using kinds of destinations.
-		private void InstallPackage(Upset package, TemporaryDirectory td, DependencyDefinition dependencyDefinition, bool updateLockfile = false)
+		private void InstallPackage(Upset package, TemporaryDirectory td, DependencyDefinition dependencyDefinition, bool updateLockfile)
 		{
 			if (dependencyDefinition == null)
 			{
@@ -694,7 +696,7 @@ namespace Uplift
 			InstallPackage(package, td, definition, updateLockfile);
 		}
 
-		public void UpdatePackage(PackageRepo newer, bool updateLockfile, bool updateDependencies = true)
+		public void UpdatePackage(PackageRepo newer, bool updateLockfile = true, bool updateDependencies = true)
 		{
 			InstalledPackage installed = Upbring.Instance().InstalledPackage.First(ip => ip.Name == newer.Package.PackageName);
 
@@ -724,13 +726,18 @@ namespace Uplift
 					PackageRepo dependencyPR = PackageList.Instance().FindPackageAndRepository(def);
 					if (Upbring.Instance().InstalledPackage.Any(ip => ip.Name == def.Name))
 					{
-						UpdatePackage(dependencyPR, true, false);
+						UpdatePackage(dependencyPR,
+									  updateLockfile: true,
+									  updateDependencies: false);
 					}
 					else
 					{
 						using (TemporaryDirectory td = dependencyPR.Repository.DownloadPackage(dependencyPR.Package))
 						{
-							InstallPackage(dependencyPR.Package, td, def, true);
+							InstallPackage(dependencyPR.Package,
+										   td,
+										   def,
+										   updateLockfile: true);
 						}
 					}
 				}

--- a/Assets/Plugins/Editor/Uplift/Windows/UpdateWindow.cs
+++ b/Assets/Plugins/Editor/Uplift/Windows/UpdateWindow.cs
@@ -99,7 +99,7 @@ namespace Uplift.Windows
 					);
 					if (GUILayout.Button("Update to version " + bestMatch.Package.PackageVersion))
 					{
-						UpliftManager.Instance().UpdatePackage(bestMatch);
+						UpliftManager.Instance().UpdatePackage(bestMatch, true);
 						Init();
 						Repaint();
 					}

--- a/Assets/Plugins/Editor/Uplift/Windows/UpdateWindow.cs
+++ b/Assets/Plugins/Editor/Uplift/Windows/UpdateWindow.cs
@@ -99,7 +99,7 @@ namespace Uplift.Windows
 					);
 					if (GUILayout.Button("Update to version " + bestMatch.Package.PackageVersion))
 					{
-						UpliftManager.Instance().UpdatePackage(bestMatch, true);
+						UpliftManager.Instance().UpdatePackage(bestMatch, updateLockfile: true);
 						Init();
 						Repaint();
 					}


### PR DESCRIPTION
This PR aims at solving partially the problem opened [here](https://github.com/DragonBox/uplift/issues/81).

Here I ensure that no modification to the lockfile will be made, by adding a `updateLockfile` parameter.

Modifications of the lockfile were performed in `InstallPackage`, which was always called with `updateLockfile` parameter set to `true`.

Also, this is just a solution for lockfile modifications. This error reveals an issue in transitive dependencies resolution algorithm which will need to be examined.

**NOTE :** We need to merge [this PR](https://github.com/DragonBox/uplift/pull/82) before merging this one.