### PR TITLE
Debug/add a log handler

### DIFF
--- a/Assets/Plugins/Editor/Uplift/Export/Exporter.cs
+++ b/Assets/Plugins/Editor/Uplift/Export/Exporter.cs
@@ -27,8 +27,8 @@ using System.IO;
 using System.Xml.Serialization;
 using System.Linq;
 using UnityEditor;
-using UnityEngine;
 using Uplift.Schemas;
+using UnityEngine;
 
 namespace Uplift.Export
 {

--- a/Assets/Plugins/Editor/Uplift/Initialize.cs
+++ b/Assets/Plugins/Editor/Uplift/Initialize.cs
@@ -45,6 +45,8 @@ namespace Uplift
 
 			if (LockFileTracker.HasChanged())
 			{
+				Debug.Log("Initialize");
+				Debug.Log("Lockfile has changed !");
 				UpliftManager.ResetInstances();
 				UpliftManager.Instance().InstallDependencies(strategy: UpliftManager.InstallStrategy.ONLY_LOCKFILE);
 				LockFileTracker.SaveState();

--- a/Assets/Plugins/Editor/Uplift/LogAggregator.cs
+++ b/Assets/Plugins/Editor/Uplift/LogAggregator.cs
@@ -65,7 +65,7 @@ namespace Uplift
 		public static LogAggregator InUnity(string onSuccess, string onWarning, string onError)
 		{
 			LogAggregator LA = new LogAggregator(onSuccess, onWarning, onError);
-			//LA.StartAggregating();
+			LA.StartAggregating();
 			return LA;
 		}
 
@@ -148,7 +148,7 @@ namespace Uplift
 		{
 			if (!started) return;
 			LogHandlerUtils.ReplaceLogHandler(originalHandler);
-			//FinishAggregating();
+			FinishAggregating();
 		}
 	}
 }

--- a/Assets/Plugins/Editor/Uplift/LogAggregator.cs
+++ b/Assets/Plugins/Editor/Uplift/LogAggregator.cs
@@ -53,7 +53,6 @@ namespace Uplift
 
 	class LogAggregator : ILogHandler, IDisposable
 	{
-		//TODO reactivate Log aggregator
 		private List<string> logs;
 		private ILogHandler originalHandler;
 		private LogType aggregatedLevel;

--- a/Assets/Plugins/Editor/Uplift/LogAggregator.cs
+++ b/Assets/Plugins/Editor/Uplift/LogAggregator.cs
@@ -53,6 +53,7 @@ namespace Uplift
 
 	class LogAggregator : ILogHandler, IDisposable
 	{
+		//TODO reactivate Log aggregator
 		private List<string> logs;
 		private ILogHandler originalHandler;
 		private LogType aggregatedLevel;
@@ -64,7 +65,7 @@ namespace Uplift
 		public static LogAggregator InUnity(string onSuccess, string onWarning, string onError)
 		{
 			LogAggregator LA = new LogAggregator(onSuccess, onWarning, onError);
-			LA.StartAggregating();
+			//LA.StartAggregating();
 			return LA;
 		}
 
@@ -147,7 +148,7 @@ namespace Uplift
 		{
 			if (!started) return;
 			LogHandlerUtils.ReplaceLogHandler(originalHandler);
-			FinishAggregating();
+			//FinishAggregating();
 		}
 	}
 }

--- a/Assets/Plugins/Editor/Uplift/LogHandler.cs
+++ b/Assets/Plugins/Editor/Uplift/LogHandler.cs
@@ -40,7 +40,7 @@ public class LogHandler : IDisposable
 		output = logString;
 		stack = stackTrace;
 
-		OutputStream.WriteLine(output);
+		OutputStream.WriteLine("[" + type + "]" + output);
 		OutputStream.Flush();
 
 		if (ShowStackTrace)

--- a/Assets/Plugins/Editor/Uplift/LogHandler.cs
+++ b/Assets/Plugins/Editor/Uplift/LogHandler.cs
@@ -6,18 +6,18 @@ using System;
 
 public class LogHandler : IDisposable
 {
-	public bool ShowStackTrace = false;
-	public string LogFileName = "log.txt";
+	public bool showStackTrace = false;
+	public string logFileName = "log.txt";
 
 	private string output = "";
 	private string stack = "";
 
 	private StreamWriter OutputStream;
 
-	public LogHandler(string logFileName = "uplift.log", bool appendToCurrentLogFile = false, bool showStackTrace = false)
+	public LogHandler(string fileName = "uplift.log", bool appendToCurrentLogFile = false, bool showStack = false)
 	{
-		ShowStackTrace = showStackTrace;
-		LogFileName = logFileName;
+		showStackTrace = showStack;
+		logFileName = fileName;
 
 		OutputStream = new StreamWriter(logFileName, appendToCurrentLogFile);
 
@@ -43,7 +43,7 @@ public class LogHandler : IDisposable
 		OutputStream.WriteLine("[" + type + "]" + output);
 		OutputStream.Flush();
 
-		if (ShowStackTrace)
+		if (showStackTrace)
 		{
 			OutputStream.WriteLine("[--> Stack Trace <--]");
 			OutputStream.WriteLine(stack + "[-------------------]\n");

--- a/Assets/Plugins/Editor/Uplift/LogHandler.cs
+++ b/Assets/Plugins/Editor/Uplift/LogHandler.cs
@@ -1,0 +1,53 @@
+using UnityEngine;
+using System.Collections;
+using System.IO;
+using System.Text;
+using System;
+
+public class LogHandler : IDisposable
+{
+	public bool ShowStackTrace = false;
+	public string LogFileName = "log.txt";
+
+	private string output = "";
+	private string stack = "";
+
+	private StreamWriter OutputStream;
+
+	public LogHandler(string logFileName = "uplift.log", bool appendToCurrentLogFile = false, bool showStackTrace = false)
+	{
+		ShowStackTrace = showStackTrace;
+		LogFileName = logFileName;
+
+		OutputStream = new StreamWriter(logFileName, appendToCurrentLogFile);
+
+		Application.logMessageReceived += HandleLog;
+	}
+
+	public void Dispose()
+	{
+		Application.logMessageReceived -= HandleLog;
+
+		if (OutputStream != null)
+		{
+			OutputStream.Close();
+			OutputStream = null;
+		}
+	}
+
+	void HandleLog(string logString, string stackTrace, LogType type)
+	{
+		output = logString;
+		stack = stackTrace;
+
+		OutputStream.WriteLine(output);
+		OutputStream.Flush();
+
+		if (ShowStackTrace)
+		{
+			OutputStream.WriteLine("[--> Stack Trace <--]");
+			OutputStream.WriteLine(stack + "[-------------------]\n");
+			OutputStream.Flush();
+		}
+	}
+}

--- a/Assets/Plugins/Editor/Uplift/LogHandler.cs.meta
+++ b/Assets/Plugins/Editor/Uplift/LogHandler.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 6275b0fb8fb6be14cbe952d32d7dd04c
+timeCreated: 1558702714
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Editor/Uplift/MenuItems.cs
+++ b/Assets/Plugins/Editor/Uplift/MenuItems.cs
@@ -94,17 +94,21 @@ namespace Uplift
 		[MenuItem("Tools/Uplift/Install dependencies (as specified in lockfile)", false, 2)]
 		private static void InstallLockfile()
 		{
+			Debug.Log("Installing from Lockfile : ");
 			UpliftManager.ResetInstances();
 			UpliftManager.Instance().InstallDependencies(strategy: UpliftManager.InstallStrategy.ONLY_LOCKFILE);
+
+			Debug.Log("-> Resfreshing AssetDatabase");
 			AssetDatabase.Refresh();
 		}
 
 		[MenuItem("Tools/Uplift/Update dependencies", false, 3)]
 		private static void InstallDependencies()
 		{
-			Debug.Log("Installing Upfile dependencies");
 			UpliftManager.ResetInstances();
 			UpliftManager.Instance().InstallDependencies(strategy: UpliftManager.InstallStrategy.INCOMPLETE_LOCKFILE);
+
+			Debug.Log("-> Resfreshing AssetDatabase");
 			AssetDatabase.Refresh();
 		}
 

--- a/Assets/Plugins/Editor/Uplift/UpliftManager.cs
+++ b/Assets/Plugins/Editor/Uplift/UpliftManager.cs
@@ -39,6 +39,7 @@ namespace Uplift
 {
 	class UpliftManager
 	{
+		protected LogHandler logHandler;
 		// --- SINGLETON DECLARATION ---
 		protected static UpliftManager instance;
 
@@ -93,11 +94,14 @@ namespace Uplift
 
 		public void InstallDependencies(InstallStrategy strategy = InstallStrategy.UPDATE_LOCKFILE)
 		{
-			Debug.Log("---> Install Dependenies with strategy " + strategy);
-			Debug.Log("====  Get Targets  ====");
-			PackageRepo[] targets = GetTargets(GetDependencySolver(), strategy);
-			Debug.Log("==== Install Packages ====");
-			InstallPackages(targets);
+			using (LogHandler LH = new LogHandler(appendToCurrentLogFile: true, showStackTrace: false))
+			{
+				Debug.Log("> Install Dependenies with strategy " + strategy);
+				Debug.Log("> Get Targets");
+				PackageRepo[] targets = GetTargets(GetDependencySolver(), strategy);
+				Debug.Log("> Install Packages");
+				InstallPackages(targets);
+			}
 		}
 
 		public DependencyState[] GetDependenciesState()
@@ -168,20 +172,20 @@ namespace Uplift
 			{
 				if (updateLockfile)
 				{
-					Debug.Log("===> Update Lockfile");
+					Debug.Log(">Update Lockfile");
 					GenerateLockfile(new LockfileSnapshot
 					{
 						upfileDependencies = upfileDependencies,
 						installableDependencies = installableDependencies
 					});
 				}
-				Debug.Log("===> Targets = installableDependencies");
+				Debug.Log("> Targets = installableDependencies");
 				targets = installableDependencies;
 			}
 			else if (strategy == InstallStrategy.INCOMPLETE_LOCKFILE)
 			{
 				// Case where the file does not exist is already covered
-				Debug.Log("===> Load Lockfile Lockfile");
+				Debug.Log("> Load Lockfile Lockfile");
 				LockfileSnapshot snapshot = LoadLockfile();
 
 				DependencyDefinition[] modifiedDependencies =
@@ -193,13 +197,13 @@ namespace Uplift
 
 				if (modifiedDependencies.Length == 0)
 				{
-					Debug.Log("===> No modified dependencies");
-					Debug.Log("===> Targets = installableDependencies");
+					Debug.Log("> No modified dependencies");
+					Debug.Log("> Targets = installableDependencies");
 					targets = installableDependencies;
 				}
 				else
 				{
-					Debug.Log("===> Found modified dependencies");
+					Debug.Log("> Found modified dependencies");
 					// Fetch all the PackageRepo for the unmodified packages
 					List<PackageRepo> unmodifiableList = new List<PackageRepo>();
 					Queue<PackageRepo> scanningQueue = new Queue<PackageRepo>();
@@ -222,26 +226,26 @@ namespace Uplift
 							))
 						.ToArray();
 
-					Debug.Log("===> Solve modified dependencies");
+					Debug.Log("> Solve modified dependencies");
 					DependencyDefinition[] solvedModified = solver.SolveDependencies(modifiedDependencies);
-					Debug.Log("===> Check conflicts");
+					Debug.Log("> Check conflicts");
 					DependencyDefinition[] conflicting = solvedModified.Where(def => unmodifiable.Any(pr => pr.Package.PackageName == def.Name)).ToArray();
 					if (conflicting.Length != 0)
 					{
-						Debug.Log("||===> Conflicts found !");
+						Debug.Log("> Conflicts found !");
 						foreach (DependencyDefinition def in conflicting)
 						{
 							if (!def.Requirement.IsMetBy(unmodifiable.First(pr => pr.Package.PackageName == def.Name).Package.PackageVersion))
 								throw new ApplicationException("Existing dependency on " + def.Name + " would be broken when installing. Please update it manually.");
 						}
-						Debug.Log("||===> Solve modified dependencies by selecting only unconflicting dependencies");
+						Debug.Log("> Solve modified dependencies by selecting only unconflicting dependencies");
 						solvedModified = solvedModified.Where(def => !conflicting.Contains(def)).ToArray();
 					}
 					PackageRepo[] installableModified = IdentifyInstallable(solvedModified);
 					targets = new PackageRepo[unmodifiable.Length + installableModified.Length];
 					Array.Copy(unmodifiable, targets, unmodifiable.Length);
 					Array.Copy(installableModified, 0, targets, unmodifiable.Length, installableModified.Length);
-					Debug.Log("===> Targets = installable dependencies with solved dependencies + unmodifiable dependencies");
+					Debug.Log("> Targets = installable dependencies with solved dependencies + unmodifiable dependencies");
 				}
 
 				if (updateLockfile)
@@ -259,7 +263,7 @@ namespace Uplift
 				if (!present)
 					throw new ApplicationException("Uplift cannot install dependencies in strategy ONLY_LOCKFILE if there is no lockfile");
 
-				Debug.Log("===> targets = installable dependencies in logfile");
+				Debug.Log("> targets = installable dependencies in logfile");
 				targets = LoadLockfile().installableDependencies;
 			}
 			else
@@ -269,9 +273,8 @@ namespace Uplift
 
 			foreach (var item in targets)
 			{
-				Debug.Log("|| -- " + item.Package.PackageName + " " + item.Package.PackageVersion);
+				Debug.Log("| " + item.Package.PackageName + " " + item.Package.PackageVersion);
 			}
-			Debug.Log("||___");
 			return targets;
 		}
 
@@ -316,7 +319,7 @@ namespace Uplift
 
 		private void GenerateLockfile(LockfileSnapshot snapshot)
 		{
-			Debug.Log("Generating a new lockfile : ");
+			Debug.Log("> Generating a new lockfile : ");
 			string result = "# UPFILE DEPENDENCIES\n";
 			foreach (DependencyDefinition def in snapshot.upfileDependencies)
 			{
@@ -397,7 +400,7 @@ namespace Uplift
 
 					if (temp.Package != null && temp.Repository != null)
 					{
-						Debug.Log("==> The line : " + temp.Package.PackageName + " " + temp.Package.PackageVersion + "was written in lockfile.");
+						Debug.Log("> The line :\"" + temp.Package.PackageName + " " + temp.Package.PackageVersion + "\" was written in lockfile.");
 						installableList.Add(temp);
 					}
 					else
@@ -441,7 +444,7 @@ namespace Uplift
 				{
 					if (targets.Any(tar => tar.Package.PackageName == ip.Name)) continue;
 
-					UnityEngine.Debug.Log("Removing unused dependency on " + ip.Name);
+					UnityEngine.Debug.Log("> Removing unused dependency on " + ip.Name);
 
 					NukePackage(ip.Name);
 				}
@@ -452,7 +455,7 @@ namespace Uplift
 					{
 						if (Upbring.Instance().InstalledPackage.Any(ip => ip.Name == pr.Package.PackageName))
 						{
-							Debug.Log("||===> update " + pr.Package.PackageName);
+							Debug.Log("> update " + pr.Package.PackageName);
 							UpdatePackage(pr);
 						}
 						else
@@ -463,7 +466,7 @@ namespace Uplift
 
 							using (TemporaryDirectory td = pr.Repository.DownloadPackage(pr.Package))
 							{
-								Debug.Log("||===> install " + pr.Package.PackageName);
+								Debug.Log("> install " + pr.Package.PackageName);
 								InstallPackage(pr.Package, td, def);
 							}
 						}
@@ -512,7 +515,7 @@ namespace Uplift
 		// This should be contained using kinds of destinations.
 		private void InstallPackage(Upset package, TemporaryDirectory td, DependencyDefinition dependencyDefinition, bool updateLockfile = false)
 		{
-			Debug.Log("======> Installing package " + package.PackageName + " " + package.PackageVersion);
+			Debug.Log("> Installing package " + package.PackageName + " " + package.PackageVersion);
 			if (dependencyDefinition == null)
 			{
 				throw new ArgumentNullException("Failed to install package " + package.PackageName + ". Dependency Definition is null.");
@@ -628,7 +631,7 @@ namespace Uplift
 
 				if (updateLockfile)
 				{
-					Debug.Log("======> Updating Lockfile entry for " + package.PackageName);
+					Debug.Log("> Updating Lockfile entry for " + package.PackageName);
 
 					LockfileSnapshot snapshot = LoadLockfile();
 					int index;
@@ -638,16 +641,12 @@ namespace Uplift
 						if (snapshot.installableDependencies[index].Package.PackageName == package.PackageName)
 						{
 							found = true;
-							Debug.Log("||--> Change " + snapshot.installableDependencies[index].Package.PackageName
-									+ " " + snapshot.installableDependencies[index].Package.PackageVersion);
 							break;
 						}
 					}
 					if (found)
 					{
 						snapshot.installableDependencies[index].Package = package;
-						Debug.Log("||-----> for " + snapshot.installableDependencies[index].Package.PackageName
-									+ " " + snapshot.installableDependencies[index].Package.PackageVersion);
 					}
 					else
 					{

--- a/Assets/Plugins/Editor/Uplift/UpliftManager.cs
+++ b/Assets/Plugins/Editor/Uplift/UpliftManager.cs
@@ -316,7 +316,7 @@ namespace Uplift
 
 		private void GenerateLockfile(LockfileSnapshot snapshot)
 		{
-			Debug.Log("generating a new lockfile : ");
+			Debug.Log("Generating a new lockfile : ");
 			string result = "# UPFILE DEPENDENCIES\n";
 			foreach (DependencyDefinition def in snapshot.upfileDependencies)
 			{
@@ -397,7 +397,7 @@ namespace Uplift
 
 					if (temp.Package != null && temp.Repository != null)
 					{
-						Debug.Log("==> The line : [" + line + "] was added as : " + temp.Package.PackageName + " " + temp.Package.PackageVersion);
+						Debug.Log("==> The line : " + temp.Package.PackageName + " " + temp.Package.PackageVersion + "was written in lockfile.");
 						installableList.Add(temp);
 					}
 					else
@@ -721,7 +721,6 @@ namespace Uplift
 
 		private void UpdatePackage(Upset package, TemporaryDirectory td)
 		{
-			Debug.Log("/!\\ Will nuke " + package.PackageName + " " + package.PackageVersion + "(Nuking all version ?)");
 			NukePackage(package.PackageName);
 
 			// First or default returns the first DependencyDefinition which satistfies dep.Name == package.PackageName

--- a/Assets/Plugins/Editor/Uplift/UpliftManager.cs
+++ b/Assets/Plugins/Editor/Uplift/UpliftManager.cs
@@ -94,12 +94,10 @@ namespace Uplift
 
 		public void InstallDependencies(InstallStrategy strategy = InstallStrategy.UPDATE_LOCKFILE)
 		{
-			using (LogHandler LH = new LogHandler(appendToCurrentLogFile: true, showStackTrace: false))
+			using (LogHandler LH = new LogHandler(appendToCurrentLogFile: true, showStack: false))
 			{
 				Debug.Log("Install Dependencies with strategy " + strategy);
-				Debug.Log("Get Targets");
 				PackageRepo[] targets = GetTargets(GetDependencySolver(), strategy);
-				Debug.Log("Install Packages");
 				InstallPackages(targets);
 			}
 		}
@@ -162,6 +160,7 @@ namespace Uplift
 
 		private PackageRepo[] GetTargets(IDependencySolver solver, InstallStrategy strategy, bool updateLockfile = true)
 		{
+			Debug.Log("Get Targets");
 			DependencyDefinition[] upfileDependencies = upfile.Dependencies;
 			DependencyDefinition[] solvedDependencies = solver.SolveDependencies(upfileDependencies);
 			PackageRepo[] installableDependencies = IdentifyInstallable(solvedDependencies);
@@ -431,6 +430,7 @@ namespace Uplift
 
 		public void InstallPackages(PackageRepo[] targets)
 		{
+			Debug.Log("Install Packages");
 			using (LogAggregator LA = LogAggregator.InUnity(
 				"Successfully installed dependencies ({0} actions were done)",
 				"Successfully installed dependencies ({0} actions were done) but warnings were raised",

--- a/Assets/Plugins/Editor/Uplift/UpliftManager.cs
+++ b/Assets/Plugins/Editor/Uplift/UpliftManager.cs
@@ -96,7 +96,7 @@ namespace Uplift
 		{
 			using (LogHandler LH = new LogHandler(appendToCurrentLogFile: true, showStackTrace: false))
 			{
-				Debug.Log("Install Dependenies with strategy " + strategy);
+				Debug.Log("Install Dependencies with strategy " + strategy);
 				Debug.Log("Get Targets");
 				PackageRepo[] targets = GetTargets(GetDependencySolver(), strategy);
 				Debug.Log("Install Packages");
@@ -748,7 +748,7 @@ namespace Uplift
 			{
 				using (TemporaryDirectory td = newer.Repository.DownloadPackage(newer.Package))
 				{
-					Debug.Log("Requiered version is not installed, updating package");
+					Debug.Log("Required version is not installed, updating package");
 					UpdatePackage(newer.Package, td);
 				}
 			}

--- a/Assets/Plugins/Editor/Uplift/UpliftManager.cs
+++ b/Assets/Plugins/Editor/Uplift/UpliftManager.cs
@@ -97,10 +97,10 @@ namespace Uplift
 			using (LogHandler LH = new LogHandler(appendToCurrentLogFile: true, showStack: false))
 			{
 				Debug.Log("Install Dependencies with strategy " + strategy);
-			  PackageRepo[] targets = GetTargets(GetDependencySolver(), strategy);
+				PackageRepo[] targets = GetTargets(GetDependencySolver(), strategy);
 
-			  bool updateLockfile = (strategy != InstallStrategy.ONLY_LOCKFILE);
-			  InstallPackages(targets, updateLockfile);
+				bool updateLockfile = (strategy != InstallStrategy.ONLY_LOCKFILE);
+				InstallPackages(targets, updateLockfile);
 			}
 		}
 
@@ -752,7 +752,7 @@ namespace Uplift
 			{
 				using (TemporaryDirectory td = newer.Repository.DownloadPackage(newer.Package))
 				{
-          Debug.Log("Required version is not installed, updating package");
+					Debug.Log("Required version is not installed, updating package");
 					UpdatePackage(newer.Package, td, updateLockfile);
 				}
 			}

--- a/Assets/Plugins/Editor/Uplift/UpliftManager.cs
+++ b/Assets/Plugins/Editor/Uplift/UpliftManager.cs
@@ -96,10 +96,10 @@ namespace Uplift
 		{
 			using (LogHandler LH = new LogHandler(appendToCurrentLogFile: true, showStackTrace: false))
 			{
-				Debug.Log("> Install Dependenies with strategy " + strategy);
-				Debug.Log("> Get Targets");
+				Debug.Log("Install Dependenies with strategy " + strategy);
+				Debug.Log("Get Targets");
 				PackageRepo[] targets = GetTargets(GetDependencySolver(), strategy);
-				Debug.Log("> Install Packages");
+				Debug.Log("Install Packages");
 				InstallPackages(targets);
 			}
 		}
@@ -179,13 +179,13 @@ namespace Uplift
 						installableDependencies = installableDependencies
 					});
 				}
-				Debug.Log("> Targets = installableDependencies");
+				Debug.Log("Targets = installableDependencies");
 				targets = installableDependencies;
 			}
 			else if (strategy == InstallStrategy.INCOMPLETE_LOCKFILE)
 			{
 				// Case where the file does not exist is already covered
-				Debug.Log("> Load Lockfile Lockfile");
+				Debug.Log("Load Lockfile Lockfile");
 				LockfileSnapshot snapshot = LoadLockfile();
 
 				DependencyDefinition[] modifiedDependencies =
@@ -197,13 +197,13 @@ namespace Uplift
 
 				if (modifiedDependencies.Length == 0)
 				{
-					Debug.Log("> No modified dependencies");
-					Debug.Log("> Targets = installableDependencies");
+					Debug.Log("No modified dependencies");
+					Debug.Log("Targets = installableDependencies");
 					targets = installableDependencies;
 				}
 				else
 				{
-					Debug.Log("> Found modified dependencies");
+					Debug.Log("Found modified dependencies");
 					// Fetch all the PackageRepo for the unmodified packages
 					List<PackageRepo> unmodifiableList = new List<PackageRepo>();
 					Queue<PackageRepo> scanningQueue = new Queue<PackageRepo>();
@@ -226,26 +226,26 @@ namespace Uplift
 							))
 						.ToArray();
 
-					Debug.Log("> Solve modified dependencies");
+					Debug.Log("Solve modified dependencies");
 					DependencyDefinition[] solvedModified = solver.SolveDependencies(modifiedDependencies);
-					Debug.Log("> Check conflicts");
+					Debug.Log("Check conflicts");
 					DependencyDefinition[] conflicting = solvedModified.Where(def => unmodifiable.Any(pr => pr.Package.PackageName == def.Name)).ToArray();
 					if (conflicting.Length != 0)
 					{
-						Debug.Log("> Conflicts found !");
+						Debug.Log("Conflicts found !");
 						foreach (DependencyDefinition def in conflicting)
 						{
 							if (!def.Requirement.IsMetBy(unmodifiable.First(pr => pr.Package.PackageName == def.Name).Package.PackageVersion))
 								throw new ApplicationException("Existing dependency on " + def.Name + " would be broken when installing. Please update it manually.");
 						}
-						Debug.Log("> Solve modified dependencies by selecting only unconflicting dependencies");
+						Debug.Log("Solve modified dependencies by selecting only unconflicting dependencies");
 						solvedModified = solvedModified.Where(def => !conflicting.Contains(def)).ToArray();
 					}
 					PackageRepo[] installableModified = IdentifyInstallable(solvedModified);
 					targets = new PackageRepo[unmodifiable.Length + installableModified.Length];
 					Array.Copy(unmodifiable, targets, unmodifiable.Length);
 					Array.Copy(installableModified, 0, targets, unmodifiable.Length, installableModified.Length);
-					Debug.Log("> Targets = installable dependencies with solved dependencies + unmodifiable dependencies");
+					Debug.Log("Targets = installable dependencies with solved dependencies + unmodifiable dependencies");
 				}
 
 				if (updateLockfile)
@@ -263,7 +263,7 @@ namespace Uplift
 				if (!present)
 					throw new ApplicationException("Uplift cannot install dependencies in strategy ONLY_LOCKFILE if there is no lockfile");
 
-				Debug.Log("> targets = installable dependencies in logfile");
+				Debug.Log("targets = installable dependencies in logfile");
 				targets = LoadLockfile().installableDependencies;
 			}
 			else
@@ -319,7 +319,7 @@ namespace Uplift
 
 		private void GenerateLockfile(LockfileSnapshot snapshot)
 		{
-			Debug.Log("> Generating a new lockfile : ");
+			Debug.Log("Generating a new lockfile : ");
 			string result = "# UPFILE DEPENDENCIES\n";
 			foreach (DependencyDefinition def in snapshot.upfileDependencies)
 			{
@@ -400,7 +400,7 @@ namespace Uplift
 
 					if (temp.Package != null && temp.Repository != null)
 					{
-						Debug.Log("> The line :\"" + temp.Package.PackageName + " " + temp.Package.PackageVersion + "\" was written in lockfile.");
+						Debug.Log("The line :\"" + temp.Package.PackageName + " " + temp.Package.PackageVersion + "\" was written in lockfile.");
 						installableList.Add(temp);
 					}
 					else
@@ -444,7 +444,7 @@ namespace Uplift
 				{
 					if (targets.Any(tar => tar.Package.PackageName == ip.Name)) continue;
 
-					UnityEngine.Debug.Log("> Removing unused dependency on " + ip.Name);
+					UnityEngine.Debug.Log("Removing unused dependency on " + ip.Name);
 
 					NukePackage(ip.Name);
 				}
@@ -455,7 +455,7 @@ namespace Uplift
 					{
 						if (Upbring.Instance().InstalledPackage.Any(ip => ip.Name == pr.Package.PackageName))
 						{
-							Debug.Log("> update " + pr.Package.PackageName);
+							Debug.Log("update " + pr.Package.PackageName);
 							UpdatePackage(pr);
 						}
 						else
@@ -466,7 +466,7 @@ namespace Uplift
 
 							using (TemporaryDirectory td = pr.Repository.DownloadPackage(pr.Package))
 							{
-								Debug.Log("> install " + pr.Package.PackageName);
+								Debug.Log("install " + pr.Package.PackageName);
 								InstallPackage(pr.Package, td, def);
 							}
 						}
@@ -515,7 +515,7 @@ namespace Uplift
 		// This should be contained using kinds of destinations.
 		private void InstallPackage(Upset package, TemporaryDirectory td, DependencyDefinition dependencyDefinition, bool updateLockfile = false)
 		{
-			Debug.Log("> Installing package " + package.PackageName + " " + package.PackageVersion);
+			Debug.Log("Installing package " + package.PackageName + " " + package.PackageVersion);
 			if (dependencyDefinition == null)
 			{
 				throw new ArgumentNullException("Failed to install package " + package.PackageName + ". Dependency Definition is null.");
@@ -631,7 +631,7 @@ namespace Uplift
 
 				if (updateLockfile)
 				{
-					Debug.Log("> Updating Lockfile entry for " + package.PackageName);
+					Debug.Log("Updating Lockfile entry for " + package.PackageName);
 
 					LockfileSnapshot snapshot = LoadLockfile();
 					int index;


### PR DESCRIPTION
This PR aims at creating a Log handler for uplift. It dumps `UnityEngine.Debug.Log` console logs messages to an `uplift.log` file in order to make Uplift debugging easier.