### PR TITLE
Fix/RangeVersionRequirement restriction to another one

### DIFF
--- a/Assets/Plugins/Editor/Uplift/Common/VersionRequirements.cs
+++ b/Assets/Plugins/Editor/Uplift/Common/VersionRequirements.cs
@@ -335,9 +335,9 @@ namespace Uplift.Common
 				var otherRange = other as RangeVersionRequirement;
 				if (lower == otherRange.lower && upper == otherRange.upper) return this;
 				// self include other?
-				if (IsMetBy(otherRange.lower) && IsMetBy(otherRange.upper)) return other;
+				if (lower <= otherRange.lower && upper >= otherRange.upper) return other;
 				// other include self?
-				if (other.IsMetBy(lower) && other.IsMetBy(upper)) return this;
+				if (lower >= otherRange.lower && upper <= otherRange.upper) return this;
 				// They are overlapping or not intersecting
 				// overlap top?
 				if (IsMetBy(otherRange.lower) && other.IsMetBy(upper)) return new RangeVersionRequirement(

--- a/Assets/Plugins/Editor/Uplift/Testing/UnitTesting/VersionRequirementTest.cs
+++ b/Assets/Plugins/Editor/Uplift/Testing/UnitTesting/VersionRequirementTest.cs
@@ -644,6 +644,14 @@ namespace Uplift.Testing.Unit
 					}
 				);
 			}
+
+			[Test]
+			public void ProblematicScenarii()
+			{
+				RangeVersionRequirement rangeVersionRequirement = new RangeVersionRequirement("0.9.27", "0.10");
+				BoundedVersionRequirement boundedVersionRequirement = new BoundedVersionRequirement("0.9");
+				Assert.AreSame(rangeVersionRequirement.RestrictTo(boundedVersionRequirement), rangeVersionRequirement);
+			}
 		}
 
 		[TestFixture]


### PR DESCRIPTION
See added test case for better understanding of the issue.
The issue laid in the fact that we did the check on the upper bound of the range version requirement using `IsMetBy()` but this method returns false in the situation where the upper bound are identical. Switching to operators is clearer, fixes the behavior and also provides a minor increase in performance (half as many check).