### PR TITLE
Do not update dependencies when installing several dependencies at once

### DIFF
--- a/Assets/Plugins/Editor/Uplift/UpliftManager.cs
+++ b/Assets/Plugins/Editor/Uplift/UpliftManager.cs
@@ -323,7 +323,7 @@ namespace Uplift
 						if (Upbring.Instance().InstalledPackage.Any(ip => ip.Name == pr.Package.PackageName))
 						{
 							Debug.Log("update " + pr.Package.PackageName);
-							UpdatePackage(pr, updateLockfile: updateLockfile);
+							UpdatePackage(pr, updateDependencies: false, updateLockfile: updateLockfile);
 						}
 						else
 						{


### PR DESCRIPTION
When running `UpliftManager.InstallPackages()`, several (solved) packages are solved at once and then passed for installation. However if the package already exist, it updates it to the expected version.

The issue is that this update then try to update the package dependencies in cascade, updating packages which shouldn't be.