### PR TITLE
UplfitManager: do not solve dependencies if InstallStrategy.ONLY_LOCKFILE

### DIFF
--- a/Assets/Plugins/Editor/Uplift/UpliftManager.cs
+++ b/Assets/Plugins/Editor/Uplift/UpliftManager.cs
@@ -166,12 +166,13 @@ namespace Uplift
 		{
 			Debug.Log("Get Targets");
 			DependencyDefinition[] upfileDependencies = upfile.Dependencies;
-			PackageRepo[] installableDependencies = solver.SolveDependencies(upfileDependencies).ToArray();
 			PackageRepo[] targets = new PackageRepo[0];
 			bool present = File.Exists(LockfileManager.lockfilePath);
 
 			if (strategy == InstallStrategy.UPDATE_LOCKFILE || (strategy == InstallStrategy.INCOMPLETE_LOCKFILE && !present))
 			{
+				PackageRepo[] installableDependencies = solver.SolveDependencies(upfileDependencies).ToArray();
+
 				if (updateLockfile)
 				{
 					Debug.Log(">Update Lockfile");
@@ -186,6 +187,8 @@ namespace Uplift
 			}
 			else if (strategy == InstallStrategy.INCOMPLETE_LOCKFILE)
 			{
+				PackageRepo[] installableDependencies = solver.SolveDependencies(upfileDependencies).ToArray();
+
 				// Case where the file does not exist is already covered
 				Debug.Log("Load Lockfile Lockfile");
 				LockfileManager.LockfileSnapshot snapshot = LockfileManager.LoadLockfile();


### PR DESCRIPTION
The Uplift Manager ran the depency solving algorithm in all cases of InstallDependencies, even when solving with `InstallStrategy.ONLY_LOCKFILE` which does not require the resolution.

This makes sure that this is not run when not needed.