### PR TITLE
We need to continue nuking when we find out an asset that was already…

### DIFF
--- a/Assets/Plugins/Editor/Uplift/Schemas/Extensions/InstalledPackage.cs
+++ b/Assets/Plugins/Editor/Uplift/Schemas/Extensions/InstalledPackage.cs
@@ -96,7 +96,7 @@ namespace Uplift.Schemas
 						if (String.IsNullOrEmpty(guidPath))
 						{
 							Debug.Log("Warning, tracked file not found: guid: " + specGuid.Guid + " " + specGuid.Type);
-							return;
+							continue;
 						}
 						if (specGuid.Type == InstallSpecType.Root)
 						{


### PR DESCRIPTION
… removed (or most probably not installed)